### PR TITLE
NO-JIRA: Add secret access permission for CLI manager

### DIFF
--- a/bindata/assets/cli-manager/clusterrole.yaml
+++ b/bindata/assets/cli-manager/clusterrole.yaml
@@ -3,12 +3,30 @@ kind: ClusterRole
 metadata:
   name: openshift-cli-manager
 rules:
-  - apiGroups: ["config.openshift.io"]
-    resources: ["plugins"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs:  ["*"]
-  - apiGroups: [ "route.openshift.io" ]
-    resources: [ "routes" ]
-    verbs: [ "get", "list"]
+  - apiGroups:
+      - "config.openshift.io"
+    resources:
+      - plugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - "*"
+  - apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -23,7 +23,6 @@ spec:
             - cli-manager-operator
           args:
             - "operator"
-            - -v=5
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -32,6 +31,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "openshift-cli-manager-operator"
-            - name: IMAGE
+            - name: RELATED_IMAGE_OPERAND_IMAGE
               value: quay.io/aguclu/cli-manager:latest
       serviceAccountName: openshift-cli-manager-operator


### PR DESCRIPTION
CLI manager has to access secrets because image pull secrets are stored that. That's why, this PR adds this into CLI manager's manifests.