### PR TITLE
WRKLDS-1297: Test image auto update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ COPY . .
 RUN make build --warn-undefined-variables
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
+ENV OPERAND_IMAGE=quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/clio-wrklds-pipeline/cli-manager-operator@sha256:9fec14cdb694beba7afc34198ccfd54ccdeaefe634ccff466cdde04d7ddfbe6d
+ENV OPERAND_IMAGE_2=registry.redhat.io/clio-wrklds-pipeline-tenant/clio-wrklds-pipeline@sha256:9fec14cdb694beba7afc34198ccfd54ccdeaefe634ccff466cdde04d7ddfbe6d
+ENV OPERAND_IMAGE_3=registry.redhat.io/clio-wrklds-pipeline/clio-wrklds-pipeline@sha256:9fec14cdb694beba7afc34198ccfd54ccdeaefe634ccff466cdde04d7ddfbe6d
+ENV OPERAND_IMAGE_4=quay.io/redhat-services-prod/clio-wrklds-pipeline-cli-manager@sha256:9fec14cdb694beba7afc34198ccfd54ccdeaefe634ccff466cdde04d7ddfbe6d
 COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/cli-manager-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/manifests /manifests
 RUN mkdir /licenses


### PR DESCRIPTION
There seems to be a mechanism to update the operand images in operator, when operand's image digest is changed. However, we don't know yet this feature is working properly or even for which image registry it is triggered.

This PR adds some candidate image registries to check which one will be updated. Once the test is done, this PR has to be reverted by leaving the correct image in here.

Once the PR is landed, we are going to merge something in cli-manager repository and expect that the Konflux bot will open a automatic PR to update the digest in one of the images defined in here.