### PR TITLE
WRKLDS-1297: Skip running Konflux built for some paths

### DIFF
--- a/.tekton/cli-manager-operator-pull-request.yaml
+++ b/.tekton/cli-manager-operator-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-pull-request.yaml".pathChanged() || "bindata/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clio-wrklds-pipeline

--- a/.tekton/cli-manager-operator-push.yaml
+++ b/.tekton/cli-manager-operator-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-push.yaml".pathChanged() || "bindata/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clio-wrklds-pipeline


### PR DESCRIPTION
In order to prevent infinite image build invocations, we need to only trigger image builds only when it is required. This PR skips image builds for metadata updates.