### PR TITLE
NO-JIRA: Build bundle dockerfile only manifests metadata is updated

### DIFF
--- a/.tekton/cli-manager-operator-bundle-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-bundle-pull-request.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clio-wrklds-pipeline

--- a/.tekton/cli-manager-operator-bundle-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-bundle-push.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clio-wrklds-pipeline


### PR DESCRIPTION
`bundle.Dockerfile` should only be built by Konflux when manifests, metadata and bundle.Dockerfile are updated. 
This PR applies the necessary changes enumerated in https://github.com/openshift/cli-manager-operator/pull/23#issuecomment-2154329348