### PR TITLE
WRKLDS-1309: Fix incorrect csv version value to 0.1.0

### DIFF
--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -73,7 +73,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat, Inc.
-  version: 0.1
+  version: 0.1.0
   install:
     spec:
       clusterPermissions:


### PR DESCRIPTION
`opm index add` fails with incorrect version value because it requires the version should be in major.minor.patch format. This PR fixes this.