### PR TITLE
WRKLDS-1309: Replace operand image in bundle image not in operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
 WORKDIR /go/src/github.com/openshift/cli-manager-operator
 COPY . .
-
-ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:b24ab7355e7573b07f4d61d2a292432afd2a6c44c4f1719a31f2d6647fa86c99
-ARG REPLACED_OPERAND_IMG=quay.io/openshift/origin-cli-manager:latest
-
-# Replace the operand image in deploy/07_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.
-RUN hack/replace-image.sh deploy $REPLACED_OPERAND_IMG $OPERAND_IMAGE
-RUN hack/replace-image.sh manifests $REPLACED_OPERAND_IMG $OPERAND_IMAGE
 RUN make build --warn-undefined-variables
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1260.1718293448
 COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/cli-manager-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/manifests /manifests
 RUN mkdir /licenses
 COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/LICENSE /licenses/.
 LABEL io.k8s.display-name="CLI Manager Operator" \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,14 +2,14 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as bui
 WORKDIR /go/src/github.com/openshift/cli-manager-operator
 COPY . .
 
-ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:b24ab7355e7573b07f4d61d2a292432afd2a6c44c4f1719a31f2d6647fa86c99
+ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:ec03071a0d4c83260b9c71a58bedfe006c18c9c1fb2b9b8f9ce4389da7f39e39
 ARG REPLACED_OPERAND_IMG=quay.io/openshift/origin-cli-manager:latest
 
 # Replace the operand image in deploy/07_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.
 RUN hack/replace-image.sh deploy $REPLACED_OPERAND_IMG $OPERAND_IMAGE
 RUN hack/replace-image.sh manifests $REPLACED_OPERAND_IMG $OPERAND_IMAGE
 
-ARG OPERATOR_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9-operator@sha256:39ddf9f04869641da8fc8506fec15bf218531bc9f18ce937cd76eeb91dca49a5
+ARG OPERATOR_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9-operator@sha256:2b2977ab72c180dd5cc84bfcc0a6900e7dd0a653b1fd5ca83b44fd2c4dff25c2
 ARG REPLACED_OPERATOR_IMG=quay.io/openshift/origin-cli-manager-operator:latest
 
 # Replace the operand image in deploy/07_deployment.yaml with the one specified by the OPERATOR_IMAGE build argument.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,6 +2,13 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as bui
 WORKDIR /go/src/github.com/openshift/cli-manager-operator
 COPY . .
 
+ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:b24ab7355e7573b07f4d61d2a292432afd2a6c44c4f1719a31f2d6647fa86c99
+ARG REPLACED_OPERAND_IMG=quay.io/openshift/origin-cli-manager:latest
+
+# Replace the operand image in deploy/07_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.
+RUN hack/replace-image.sh deploy $REPLACED_OPERAND_IMG $OPERAND_IMAGE
+RUN hack/replace-image.sh manifests $REPLACED_OPERAND_IMG $OPERAND_IMAGE
+
 ARG OPERATOR_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9-operator@sha256:39ddf9f04869641da8fc8506fec15bf218531bc9f18ce937cd76eeb91dca49a5
 ARG REPLACED_OPERATOR_IMG=quay.io/openshift/origin-cli-manager-operator:latest
 

--- a/deploy/03_clusterrole.yaml
+++ b/deploy/03_clusterrole.yaml
@@ -49,6 +49,7 @@ rules:
       - apps
     resources:
       - deployments
+      - replicasets
     verbs:
       - create
       - delete

--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -116,6 +116,7 @@ spec:
             - apps
           resources:
             - deployments
+            - replicasets
           verbs:
             - '*'
         - apiGroups:

--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -36,24 +36,25 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-  name: cli-manager-operator.v0.1
+  name: cli-manager-operator.v0.1.0
   namespace: openshift-cli-manager-operator
 spec:
   customresourcedefinitions:
     owned:
-    - kind: CliManager
-      name: climanagers.operator.openshift.io
-      version: v1
-      displayName: CLI Manager
-    - kind: Plugin
-      name: plugins.config.openshift.io
-      version: v1alpha1
+      - kind: CliManager
+        name: climanagers.operator.openshift.io
+        version: v1
+        displayName: CLI Manager
+      - kind: Plugin
+        name: plugins.config.openshift.io
+        version: v1alpha1
+        displayName: CLI Plugin
   description: An operator to manage CLI Manager
   displayName: CLI Manager Operator
   installModes:
     - supported: true
       type: OwnNamespace
-    - supported: true
+    - supported: false
       type: SingleNamespace
     - supported: false
       type: MultiNamespace
@@ -71,6 +72,9 @@ spec:
     - email: support@redhat.com
       name: Red Hat
   maturity: alpha
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAJIAAACSCAYAAACue5OOAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAkqADAAQAAAABAAAAkgAAAACRw8kvAAAoEklEQVR4Ae1dB1zU5Rv/HsexQUBAUWS4R2q5Z5qjrJxp5v4X5Spny5FlaZmaqdlw5MqVDUstTS1HllszF+bGCQ6GAsrm/zzvj9+P4zjuDu6Au8Pn4/Eb7/i97/M+vuOZqiwCPISHGDATAw5mln9Y/CEGBAYcH+LBMAbi4uIQEXEKpyMiEHE6ApGXLiE+Po5+8fS7i+TkB3BxcaWfM/1c4OXlheDgEISEhiIkJBRVqlRBo0aN4OnpZfhDNp6qeri05R3B48eOYeu2Ldiy5TecOH48b4YCvnFwcECtWrXQpElTtGjREh06Pgl3d/cC1mLd2R8SUvb48MyzatUKfLN8Ga5cuZJn1IIDNKge5IJqQc7w83KEl7saZejn6qRCalomHqRmITktC3H30nH1diou30rD1ZtpuHQzBbq7UFdXV3QkYurWvYe48kxm61DqCen8+XP44vN5+OmndbRMJSvjWc5Hg/aPedLPHY1rusPdpXDbycQHGfjn/AMcPnMfB/67jyNn7+ciLG9vb7z4UjgGDx4Kf39/5fu2dlNqCenatWv4ZOZ0fP/9d8jIyBDjpnFU4enGnhjQ0RcNq7kZGUsVVBp3qBw96eoBOKghKCQrE1mZachKi0dWagK9yxCvb8alIfFBJm7EpmH38SQiqiREROYQLs9KvXv3wegxY1GpUiUj37a+5FJHSElJiZgxYzqWLlmM1NRUMSJebg546amy6NfeB35l9J8/HNwrQe1ZGWr3inBwC6JfAJXNO0ulpqbh3xNnsf/ISRw5ehrnL17F5WvRSEuTiFWXBFQq6Y28/Dk7O2PU6DEYNWoM+N5WoFQR0qZNv2LihPGIirohxsfN2QH/e9IHQzr7g4lJF9RlqsPRpx79HoHKKf9TV2JiErbuPIhffvsLO/8+Qktkim5VBX728/PDZ/O+EHuoAhcugQKlgpBu376N18eOxtatWxQUP9eqDMb1KZd3BlK7QuPfBE7lWkLl4qfk13dz9PgZLF6xARu3/EWzW1quLJX8NWhcww21gl0QFuiEkPJOKOOmFnstR7UKCbTMJdzPRCRtxs9dS8Fh2jvtOZmEpOTMXPV0evoZLFv2DdRqWjqtGOyekHbu3IGRI17FrVu3xDBULu+MqeHl0axW7uO3ytEdThXaQ0MEBAeNwSFb/+suzF/2k1jC5Ix0wkdT2pQ/09QT7R71RHlfw3XI5bSvaelZ2PFvIpZuuUOb8wdKkrePN9b9+DPq1quvvLO2G7slJN5AT5nyPhZ89SVkGdCQZ/0wtqc/nDTZGxMeDbULnALbwql8G7o3vCfZumM/Pp6zHKfPRCrjGEgE05/2Vr3beqMssQUsBfsikjBpWRQio6V9nCPNSCtWrhY8KEt9w5L12CUhJSUl4eXwF7Fjx3aBK39vR8waWhGtHsk9Czn6NYBzcDc6dXkaxOnxk+cwfspXOPLvaSVfvcquGNbFDx0beIJno6KAFOJLffL9TSzbEiuqd3BQYc6ceejbr39RfM6sOu2OkHgJ69u3t8KR5iXs8xFB8PXK2WPw3scltCfUZWoYRF5S0n18PHcFlqzciMxMae9SraIzXu8VgCcbGSY+gxUXMPGbbbGYuipasBFUdMxbt249WrVuXcBaija7XRESMxf7vPC8wpnu2twLM4dUBPOHZNAENINzSA+j+6Adfx7C2EmfIfrmHVHUm7jY42lz3quNN+Qju1xncVy/2xmHiUujxKecnJxx6PARBAZWKI5Pm/QNuyGkgwcPYOCAfmBRB8OQZ/wwri/zerJB7QaXyr3h6FtPfqP3mpaWjqmzlmIhbaZl4BPexH7l4eOZM6vJacV5nbIyGjw7MYSFhuHAoSPF+XmD37ILQmL+0PBhQ4SIg2eLdweUJ/6Qr9JxB7fycK0+GCpnH+WdvptLkdfxyphpOBlxQSTnt7fSV7Y43mXQ6tr9vYuIuCxxxD+aNp1EK0OK49NGv2HzhLRh/c8YOvQV2sNkwZlOY7OHV0Snxl5Kx9VeVeFaLRxwNCwYPXjkFAYOex/xd0msQfDEox74hJbFkp6FlI5k37CsrvfUSPHEqiuRl6/TZr+Idvu6HzfwXPItMNA4Y0n79+3DCOIRMRF5uNLxeFxILiJyLNsArjWHGiWiTdv2oNeLEwQR8Yw2sV85LH4j2OqIiPHRsLob8aqk/yjMQZ8x/WNjaCqWdJudkc6dO4tnn+kkFMyYU7zkzeBcx3unCu3gVKmzUSQuphPZpA/n04lImtHmvhpUrCcyow3Uk+HIOZqVpkSKFF8fX/x39ryeXMX7yiZnpFs3b4rTGWspMnz0cqAWETnAOaynSUQ0ZeYSvDP1K0FEfCpbOT7ELCJ6kJKJ1dtj8eLMK0U6iqyZUDtEWqpj42Lxzz8lv+m2HCu2SFGXUzlL7/v2ewFXr14VL8c8549erb2zMzjApdogk05mI8d/ip9/2SnKBflpsOztYFQOdM75UAHubsen45vfY/HtdlLBTcoAc7uLGp6l5U3edC9auBALFi4q6k8arN+mCInFHi+Hv6QwG58nns7IHjnKYM5hvYwSETMWXxoxBb+TtJ6B/2cvpWWRT2gFhf+upAi52MZ998ByMhly7uQ3lr+2eoQOA99L8sMDB/ZZ/gMFrLHg2CvgByyZ/Z2J4xWxx+N1PfBReA5Dzqnik2BmozF4e/IXChEx13vR60EkkS8Yf+jPY4lY8lsM9pxKMva5IkuvE+oCXo55BoyOji6y75hasc0Q0q+//oKlS5eIfrGY4otRQVBn7/Ac/RvDKaiT0T7Pnb8WK7/bLPLxTFQQImK514Y98VhCcq/z1w3rG+Xw0Y02qdAZ+HRZrRJxuEl9l2fqhIR7JWqpYhOExGqxY8eMEkjnExrzimQdarV3DbiE9TY6ID9s2C4k95yR9zBL3qxk0kwUey8Dq/6IxSra/8SQYr8poFIVx+IGhJKOExMSw4njJ9CiJanAlBBYPSHxsZy51nfv3hUoGk17IvnE4uBWEa5VXwRUhpemv/b9izETZovynq4OYmMd4G14Q3zhRoqYfdb/HQ+ejQoCapLSFweEBjgpnzlz9sxDQlKwoedm8deLcODAfpFSP1t1gx9Y9cO1JokHjOgQRZy5hBdfm4r09AwhvF0wthJ4acwPrt1Jw3vLo8D7oMICq3sUB3i553BvHB0N/2cq6vbktKSov1SI+nlJmzbtQ1HSxckBs4ZXUHR/XMJeMKpHFBt3D/0GvwfWqWaYMbhCHs1IkaD158zVFLOIiKtS8wamGMBJozV8BZs0Ld46rZZYvG6zK3zrzdfBSmoMb78QAFaTZdAENIXap7a4N/Rn1PhZiIq+LbIwv6lbizKGsos0S5AAWyYVB7hoqcekpBg+ABR1e6yWkDZv3oTt2/8Q/edjuizNVzmXJa3G7kbxsmj5z8oxnznBI7rn8JuMFjYzg3yaNLMao8VTtPb+GifDez6jlZmZwSoJKT09Xehbc994UD58KTC7myq4VOlrdF908vRFTPlEYhWwydHMoRVMVkazxImruDbb8Yk5lOTjbVhFxkw6MVrcKglp+bKluHhB0gnq185HmPNwTzQV2gojRUO9Ys71mImzySBRQjKbHIWWyzndGCrLaRZZ2ixRibGGUjozI2Xw9nlISDIuxJVlabNmzRT3rBoyqoek5cjKac5BT+fKq+9h/tJ1OHHqvEhiZf8BHYofwczrKg6IIR6XDL6+ZeXbErla3Yy0nLyBxMbGCmQMfqasorTvHPo8TReG2V6RV6Iwc94qUZb5RXxKKyiwcr25UFxLG/O6GLjNYWFh5jbbrPJWRUhsi79gwXzRIZZ/DcpWl2U9a7WncUS9+9ECxVx68v8CC2WkaIm1TVVMWD1PFroM7HSipP0tFVOXRX+N/lm7dg1uZgsg+7XzluzxaVScg7sYLbvnwDFs23lA5GtSyw09Who/6huttJAZimNlY9UVeY9Uo2bNQrbUcsWsipAWLlggesbmQy8/La35mgCywacjvzGYPP1rJcs7fcsr9wW9scDKRnb65i+Pxtp97FKOSXed2nWMZS/ydKshJDYnYvVZho4NPSX9IJqNnAKfMIqEdaSgJm+wmen4SJiL0TJFmaE49kj7tFRYWrZqXZTdMaluqyGk1atWKg1+oa100nL0a0Szkaz9qCTnuWH1EAbmOb3+vHTKy5PJxBeWmEuKw6hj7ylJ6u/k5ISmTY3rYZnY/UJnswpCYjHIxo0bRCcqktpryzpso6+Cc2B7ox3bsn0fzp6/LPLxbMRqsyUNjkWMVd4fnb2WLLrZqHFj4U23pPtcxF02rXssCpFlat1ok8z7FLV3dahcjYs1PlvwnfKRoZ0N+zNSMhq4scTxv6il/1sPS7Z33I327TsY6E3xJVkFIW0lN8QysHcPBo2/8emavYP8c+w/kb8DOQ6takA9RGQqpj9FvUfauO+u6AkTfffuzxVTrwx/psQJidVEf/99m2glK+CzuxiVowe526truOWUuuqHrUqe/h0tw8G2RESNotwjXSd9Kba2ZWjcuInVOC4tcUI6fPiQMHJkxLSjWYXB0a8hbZEMNy0p6QE2bP5T5K9Q1hGtyarCEkBGu2ZDUc5IG/dKsxE38rmevcxuq6UqMDxalvqKgXqYkGRoWtNN3Dr6Gp+NNv62m/ZVEi+lVxsfk6X78rfyu9IEaTYUlRoJu2haTbrjDG5uxHTtYR3LGrenxAnpyOHD3A4Bj1ZxpenIjcQhodlv8r9s3Pq3ktjdBIU1JbORm0zZT7GRfIaSi4qQthy+hyjy080wYOAg+JSwxF8bByVOSIezCYk9qoWQuoejN3NpDTeLZ6K/SaGfgfWvuZylgF3HmAsORcTZXp7tAlCj0eDVV18zt5kWLW94xCz6qbyVse1+dHSUSKgTQrMRgSMd+40B+7KW3RF3aGCZvZH8zQwLbJKKQmebnZOy8wiGXr2eR4UKFeUmW8W1RAnpymWJkciYqOQvzSpqj1CjiNm+O2c5bN9AcvFitJCJGTIyzN9tF8XSNmfdbdEDPvKPHDXaxN4UX7YSJaTLV7QIKcCRjv0U28MEAe2hfyIEhlxJjZbZBZYESyxtliakv04kKkf+Z555FlWrVrNkly1SV4kS0nUyN5IhyM8JDh4h8mO+13sJSTh34YpIZ/t3Sw+aJQjJ0pztLzZIsxF3moPeWCOUKCGlkCKbDGy35mCCSETmZHO5BlUkdoFchyWu7P3NXLAkH4nDc8lRANq0aYtHH33M3OYVSfkSJSThODq7W2y94eCc40A0v97+dzZnOawTmr/FbH7ljb23CCFZQqkpu6ELfr2jNNlaZyNuYIkSkrY4woGQ7+BkXIHtCoWskqGSBY/9cp0ZluAjqc2f1bg9Z64mYyfFJmHgmaiVFegdicbo+WM1hMS60oZCWcltv3xdi5BoX2VpyMikhpgJhvZITKfaAf8MfWrBLzmz0ZixrxvKWuJpVkNIYjUwIl9jbF27fksgjU9s2mEhLIVJiyxtehiSHD6Lna23e/McrpLg1RhcvZ2GTQfuiWzVqlXH0xRuy5rBsSQb51UmR0H/ZhwbNBpfElLTpEFwoaDERQHpluAjae2RWKSxYmsc1u6KxT2Kz8bm50+ZEMfk6013IJ8gmW9kCT2posCXXGeJEhKHMJdBNq2Rn/O7ylsYrbHKL2uh3ltkj0Tz/AlSzl/yWyw2H7irEASrl3BUAmPADr3W/SVJ+ZmDzZxsa4cSJaSaNXMI6Ry70zOFOrIpiUITFwluMy0g/V+8OQazfpCWYO1G9mnri5rBxk+ay7bEIDlVEvqNGDESjo4lOkzaXcj3vkT3SGXLllVClJ9lY7/sUFb5tpYS5JOeKTRnqJ780kxoQn5FlfeyvZnygm44Zu7rvYyrDnN4d1lVxNfXF/36D9CuxmrvS5SQGCvyrMR7iTtRkfzKJCgqQrKE0FZfB9iHgSlxTZiIeC/FMGTIMKF3pK8+a3tX4oTUuvXjCk5+2rRbuc/vxstTkvbH0j5C27d1fvkL+t4Ce+08n2QHYQNNUAVOJV+Vy7ZKfg88PDwQ/vIreeqy1hclTkh9+vZVIkh/u+mYUTzVqh4i8vCJ5lK0ZPtutFABMhTFjPRO/wCY4qFkHTk+ZVMjhkGDXoS3t3GbvgJ0rUizljghlS8fiPYdOohO/hd5N1fkan09r1k9VHl9lvw9WhoswUfSblOb+h5oS1G3jQHvzb7eFCOysdHjsOHDjRWxqvQSJyTGxoABgxSkLFk4D5kPbirPujc1q4Uqr84acZyuZCzAjSV0tuXPsWbCpP7l5EeDV2YTXL4pCbF7v9AH/B/MlsAqCKljxycREiItWd9vO48d372HB2eXIDMhMg8u5aWNE+SgLnkymfHiQfax24wqlKLslsfUQDkLs2cjDuI3csQopQ5bubEKQlJTTPt5875UuLdvL7qBuzeO437EPNw/ORvptw8Ra0DiaAeW90flMEnN9K8TSWDP/JaAHUcT0X/aZfLyL1lpmFsnn9Bkb3PG6mKf3vJ/ii5duyGscmVjRawuXf0+gTW0ip1FJSQkgM2TEuj4y27tOpDVbVbaPaTHnUTqrb3ISk8kDQFPpKQ7Yffeo2DVIT8yqmxAXmsLAxxf7YfdcRg7/zpWUJgsdtZuKXiHlrRGFO3RFBi/5AZuZH/7qy8XoFw505ZDU+ourjxWFUGSfUW3b9cWZykcAsPSt4LRpp503Bcvsv/EpJRF86F7KJhLJqpUcMa2GVW0k43e88loBcUX4fhqcYmWmdG0P1qDgs38+mEVxbm8dpru/T/n7+P5DyLF63bt2mPtdz/oZrGJZ6tY2mRMOTs748uv5ivsgElLbyApOe9Al3WOQfvH3EUx9qN48LRkXSHXk9+VxQ7jaNlsPfYcvtpwp0iIiL/N8jRTzbYXbMxRFRk1ekx+Tbf691ZFSIyt+vUfxWuvjRSIuxGTjhlr88qsOHFQxxxtyneWRimyKVEwnz+sztuMXObIgt98spn1+kmS7DevLRG5sYpYvrid9mYMjRo1RosWLY0Vsdp0qyMkxtRbb49D5SrScsUiAzmUlDYWebCebysx7C4SY1KfkFQ7v3zPviU5kHJBg/3J5Q1dnShc/IQCuB1cqKW4Zs1qtIb6LKdZJSHxEjd3zjzlFMebUX2hrt6lDa3sWGsZWaEeyI5dJncuvyv73147KaRQ4Ufzq5Pfh3fyRXCAaY6+2KuI7J6mRo2aeOqpToaqtvo0qyQkxlqz5s0RHv6yQGBkdCrm/ng7DzJ5VvlkiMQK4MRxi67jPp3ETAGO+bZucpjJfB5jdbJLnle7+hnLpqQv3pyjuGbLeyO5Q1ZLSNzASe++h4oVg0RbF2+5I5TF5IbLV3aF/OJT0n6J1VM/1aMHJOfVvbKbwR8mh6Khicd03fLaz2/2DjB5uWTe1/d/SoprzPZ47rme2lXZ5L1VE5K7uwc+/XS2QCzLosZ9fQP6VGHfIAeklfylJYX1ovlIbSpwgOGV40PAm+TCQt0wV62Q8cZrWb4tR3HtVTpYMEPW1sGqCYmR2458JPbp01fgmYPy8bFdFzgC0rSXK4jXfCIb/3UUWCXDVHCmTfJXoyphYCHjlrw70HQGIhsBcIxcBj8/P/S3EcU1Y7i0ekLiDkyZ+hECAgJEX76ik45Qy9XpWQs61sunOOYtfa5l5qyTVe8jK8q9T2En3qIlqiDQpXkZcDw4U2HNjjjcTZL2cay45uLiYmpRq85nE4TEejnTZ3wiEMnKbMxU1McLeqdfOchBj/loLcuvCjICw7r44dNhFU3SH2KTqHF9TCc8bvtSMghg8PDwtCnFNWM4tAlC4k507twFzz7bWfTn2EWy0CAFeV3wpLBcU1+SrDRY8W3c4huKBYduXkPP3YnXxOIZY7ymIRS9iUO/mwo//RWPW/GSPO+ll8Lh5eVlalGrz2czhMSYnDFzlqI1OIfYAbL+jjaWWdDbmZYbBrZoXZStnqGdx5R7dhpviNfEBDSks3ETc/lbPIMuIusSBuaTDR06TE6yi6tNERLvk6Z+OE0gnuVmE2jG0QeTSdYlK9rP+/kWmPNdGDDEaxpPSxqLXEyF3w7dA/PDGPr06YcAG5TwG+qr6ZgwVEsxpr1A2oNPPNFOfJE52d/uzKs/xKbc7w2Uljg+vfEpTt+eypRm6+M1Md9JnvVMqYPzyHb8fNR/jWzV7A1sjpB4AD6dPZc2q5J6yfRvbyE629Or9uB0peXtiUelPOzgnPWNCgsyr0k2tX7PBGtZ7W+xx7VTtMwydO3WHaGhoeLenv7YJCEFBQUR13uyGAc2KJy0THJoqjswHJ2b4+IyMMfbHMU15jV9Sbym+aMrFTiM14Jfcg4GI0eO1m2mXTzbJCEx5lkO16xZMzEI7ENog5ZHfHlkytOGeEL28ZwZge+Q8NccYF5TQTngfMLcfzpJfLZ9h4545JFHzGmC1Za1WUJijM6ZO09h6E1dGa1Xf7sPhXtnDyAMf59MItXaeHFfXH/maymujRk9trg+W+zfsWlCqlKlqtBdYqyxyuzkFfqXuGkvB4KZhwzTVkcrRojiRRH+YQ7770cSxBeaNGmKptkzaBF+ssSqtmlCYqy9+uoI1KtfXyBwMzmm+uMfaeC0McqRAcb2lBw4sF39u8v1E5x2GUvcL9T2/2jHsxHjyuYJiY/Tn332heL6hTfeshMGbWII71QW9bN9cvMssfmg5A1NO48l79kpxoa90jdq166Njk8+acnqra4umyckxmidOnUUb/hsITJtTY6fSRnjvFGeMaQCOII3w/vfRBeZ8j/Xzz6SZJUXe1Bc4z4ZArsgJO7gG2+8herVa4i+/vBnPPZoRaGWEcABcF7L1mJkr2gfrspLcHJec668X/t+l7SpZwvibt16mFOdTZS1G0JixwtzP5tHZkBSlyaS+ESf2u1wIiS2O2NYv+cudv2bd09l7sixcp38beZi24PimjGc2A0hcUfZpOeVwUNEn5n5OOv7vKZM7F5mxuAKit3ZpGXRem3njCEuv3QmoJVESAwsG+zbt39+We3qvV0REo/MxImTFIcULBaRQ1Npjxqrxr7SSVLU503x9G/zGhZo5y/I/VpSXJNd/w0hCT9L+ksD2B0hcYhOlsUxGFK7Hd3TD6HlnUS+NTtiTbbWFQXy+cOKa0uyg/N5enqBdY5KC9gdIfHAPf54G/QfMFCM4cWoFLAqiS6wCsj0bD1vTptA4hPZk6xuXlOfec8lC5DDw8PBxFRawC4JiQfvgw+mKs6qWLlNX9iGxhSMuX97HzHWkeTkau66wi9xQnHtV0k4y3rYQ4balsc1cwnebgmJ1VhnfjJL4Eeo3dKMw1ddYJ1rWV2W1XePk5C1MLCVAhfLCnT9+vVX3D4Xpi5bLGO3hMSD0anT0+ieHdJcqN1qiSzkwWK97I/CJTd7ku1clMJIlPOYcpVVRfioz7ZqpQ3smpB4MD/+eAbY8TnDvPW3wXsmXWCHoexcguHstWR8qSWx182r73kvMT85ZARDDyLc4OBgfdns+p3dExJHF/ho2nQxiIbUbieRaq5fGUeRj40wmaBMhfnZXkWsNXCxqf0wJ5/dExIjp2fPXorQlPlK+tRuWZ32/UGSnjfLyMaRnrcp4SR4JuIZiYEFs7Vq1Rb3pe1PqSAkHtRZs2Yrx3HmeOtTu326iZeiAcmbbn22c7oEIu+N+P2oUWN0k0vNc6khpMDACpic7XeVxRgsi9MHU8hsu4y7hBZmBzBbID/gUxqf1hjYDQ8rr5VWKDWExAPMYRlatmwlxpq1A1hLQBfYz9HE/tISJ2znDOh5LyK+kWzmZM9qtLo40vdcqgiJEcB63q6urgIXrLckx/7QRk6v1t5oXVcyZWJHpyxC0YWbcWlCe4Dfs0I/e00pzVDqCIltysZPmCjGnDUp8zNlYt6Su4uEHhbqsnBXGzg6pBydqTTvjWSclDpC4o4PJfFFgwYNBQ5Yx3s87ZdkA0YZMWxh+2Zvye8Ru2hmdRMZWLq/NtvClwmTjR5LO5RKQmLlN1aC02gkTyK8V+r67kV0ox+bgMu+vQdRjDXZLSArwLFQloH1jdhOjmHEyFGKMp14UUr/WJXn/+IegytXrmDVqhX49ts1uBmdM+OwB7hnm3uhT1sfeNEJrvPEi8Krro+HGj9PqYwe710U+t4cJTwi4gxYO7O0Q6klpMykSGQmXUFW0nWkJVzB738ewJpNJ/Dn0ZhcjEhWy+VljoPeMPCpTt6gjx7QCG8O7w4HtyD6VYLak3yDa0qP6oj2f55SQ0iZiReQEXMUGbFHKUjOv8hKlZYpbWTwPesTseI+B7vhyAMysBWKfNTndxyL7ejCGrmccbGIxMGjMtS+j2X/HoVKI8nw5Hrs9WrXhJR1n2ab65votxmZyXcKNIZMNLuPJ2Ltrjhspw25rgpKM4o8sHpCiME6mbDUvg2gCeoMx3JtyIrQfpdA+yOkrAykR/2BtGu/ID32X4MDrZuY5eiBdFUZpEOD9ExHpGWoKaSXCvH3kvHb3kis/PUc7iVJbICNH1ZHnRBJyKtbj75nlcYDmsCO0AQ/R7NWmL4sNv3OrggpPep3pJxbjEyaiQxBlkqDOyn+OButwenLiTh+5hYOHLuMO/GmS/x5qatTNQCN6gahThVf1A7SIMQ3Ea7IcWGjrw08SzmWbw/n6kOgcpVcOuvLZ2vv7IKQsh6QvvXJGUiPOZIv/hPSy+Dv/9T4accF/HU0WmEm5lugkAn+Phr07FADzzTzQ62AOLKJz83IlKtVqZ3hVPVlOIX1oVe2z4WxeULKuL0HD45PpUiT0qlKHii+pmdpiHjIGfuPZ8Fe24ob2MlXr7YBCH+2EiqWyds+bo+jX2O41v/A5k97Nk1I6bSJTj75MZ2maGesBZlZKjp1JeCT764jLiFv4ECtrOKWTZhCQ0PpF4bAQBKNUOgKfufu7g5XN1ekp2fg/v0kJCUl0fU+7t69iyuXL+PSpUuIirpB7AI9yuA6H2GH8lPCQxCmxy23g0cw3Jp8AZWTpMmpU9QmHm2WkDJu0Ux0dAIRUe5BPHYxGW8tvA72TaQP2MKjYcNGaNGyJXl8a44a5C/AHA+zqampuHw5EseOHcPevXvE7+KFC/o+TWHDgBee8MHkgYFw0tmnMw/KrfkiWuVs06DSJgkpKyUGSX8PFIGTtUfs13138TYFvtGN7cZe9rt1747nn+8tzLpN5kRnPCB+U5wYXJWTN6AyLfjMrZs3sW3bVsExP3TooHYTxT2711k4tlKeeHFOlbrBuc5befLbwgubJKSUiFlIvbI+F37ZydbIL67levfYYw3wEvma7Eoh0HmpMgyZyIg7gfSbu5FxZz8yH0QjKyNnVuPTFnOt1V7V4RjQmvhCraFylpx3Gar3/PlzWLN6NVasWI579yQlOM7PVr6/fFgZLI6RQaVygFurFXBwD5Vf2czV9ggpMxWJ25/ONcgssug0/oJic89WHO+S19tu3U1zJ5Nx5wCSI2YbZRtoj6o4xhNfyKXWGJM2yjExMfhk5nQiqG9ozyVxzPu181VCXsh1O4X2hnPNUfKjzVxz/jvYSJMz4o7nIiJu9o/kYFR23PDKK4Oxd99Bk4ko/dZuPDjyVoGIiL/JG/y0G9tw/8BrABG3MWBrFg7Ms33HLoSFhYns3+6MBbt31oaMmMPajzZzb3OElJV8Kw9yj1KgPzZM5Fgl08iOzeQ9ENWUemFFng17ng8YeJGReImWw10GcuROYiuTLVv/QPMWLei7AB8OtIGXVFsEmyMkOOgcdwjrbmQt++abbxfK+4fKAtJ6laNngcbex8cHa9asFYaUshamXEFa7glKfm31V5sjpIS0vIPWqUUQxox9vVDIdq45AsnphRemJrk2gNq/eYG/zbyqzz+bTfI6l1xlb+RVD8+Vbq0PNkdIB0/Hg/0/asOT9VVQJV/VfmXy/byv16PDG6eE9qMu28BQJRyI+V1Sv20VvhHR0VGGsuab1sDvhOIcVc70x+F4+damrjZ3alu9aiXO7JiaJ2QoH8vdmnxOMgfJy7+po9Dm8VY4fTpCZGen7q3ruqNtPQ9UIGU2vzL0o0hLyRRh6fbdNMTczcCpy8nkhP0e/ruSwxqYM+czxR+Tqd8Vop1/xotNu1yG1Xc7vXMV/54q3H8KuZ6SuObdcJREKwrwTU9PTyzfGiucPlQlL7UyZNw7i/v7h8G14UySqgfKr41e69WrpxDSAzKc3HY4QfyMFszOwGyAR+rWNTW7yJd29WekRMzNRUScMGfdLWSoJDOoAlVoBZltbmmrQzZkbLg44vNrSpBhGY98grq/bzBYBkcHdPm1wSsHXmaRSWGAT4ofUiDC+vUfNak4c+STScCcfOpTIqLcu2pmqC4jt4G1a9cxqS5ry2RzhMTxR2rWrCUibf9vxmWFfyQjNjM1Hg9OTMP9veGkWmucJ8MnqE2bt+DTT+egadNmJlmEcBkOQLh9x58YPGSo/On8rxn3kXp+KZJ2v0C8p6158m2lWXDsfEmHqkuXrnnSbeGFze2RGKnrf/4JQ4a8IvBbyV+D+WOCUSs4Z5nTRryDezCpuj4DTYWnSaRRVjtJ7/2dO3ewa9dOXLt6Fbdu3cRtenYlQa+/f4Bwd1yXlkImOFN8Z7N+OKv6pkfvIiZqbn6R/PEv1t8RSxo/V6wYhAMHDxeIDybXU9JXmyQkRtqggf2xZctvAn8cFoI9+nOodTlEhC5iVSRwVZdtSL8GcPR5DA5laposhNWtK7/nLJoNM8iwIINUfNNv7yVu+Y38sgrthIlLo3D4jKQnxXut739YhzZt2uZbxpoTbJaQWCeoR/cuOHnypIJfjoI05jl/dKEwpCxjNQQqtQvU3nWE/rSDGzlwd6sIFZsVuZAgltLy1VokcUhWehJYK5NVesUv6Roy751BRmKkoU+KtJiELMz7KRrfkaWKbPLNCR9MmYrhw0ncYqNgs4TE+I6NjUXfPr1x9Og/udDPBNW3nT/6dSwHd43+JSVXAT0PrArLBKVSk8OJrHT6R679aHnS3STrKar3VcR1Db7eECnc4Gjzq9jq9/33p2DY8Ff1lrOVlzZNSIxkViybMGEcVpJUXRc4LEnb+l4Y9lw11A/NgiMKR1S69Zr6HJ/iiY17Y7Bk42W9jr38/Pzw5VcLlKjhptZrjflsnpBkpO7e/SfefusNXLx4UX6V68pLXeNaZdGzYw00qeWGip7xUGdK+5NcGQv9oML9rLI4E6XBH4eise6Ps2SRm4/iPzWmT5++eJ98gfMJ0B7AbgiJB4P1fL5dsxpz587GVTp1GYMKAe5oXj8Udav7o1qQO5lmq+FBrmw06nQ4OmTQDJZG9h20J6K/mSpnydYtk23dHBCbkCm8uf13KR5HIm7g0ImrYGenhoCXsaee6oRx4ycSv6i2oaw2l2ZXhCRjn3WF+Ai/hojqt82bxPInp5XElRXt+vTph779+okjfkm0oai/aZeEpI20uLg4rFv3I3bu3I79+/YjISFH3VU7n6Xvq1StilYtW6NL164iNoql67e2+uyekLQRzmZDJ04cx549f+PA/v04f/68sADhDbs5wA7hw8IqkwvAuuSjsiVatGhplmWKOW0pqbKlipD0IZmXwWvXrpGN2kVhq3b33l1hu5aUKNuxJQmHXLKdm2zzxkH9wipXFgTEcU9KO5R6QirtBGCp/tuc0NZSHX9Yj2Ux8H+wGc0MXDg3PgAAAABJRU5ErkJggg==
+      mediatype: image/png
   provider:
     name: Red Hat, Inc.
   version: 0.1.0
@@ -79,100 +83,100 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - operator.openshift.io
+            - operator.openshift.io
           resources:
-          - climanagers
-          - climanagers/status
+            - climanagers
+            - climanagers/status
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - config.openshift.io
+            - config.openshift.io
           resources:
-          - plugins
+            - plugins
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - coordination.k8s.io
+            - coordination.k8s.io
           resources:
-          - leases
+            - leases
           verbs:
-          - get
-          - watch
-          - list
-          - create
-          - update
+            - get
+            - watch
+            - list
+            - create
+            - update
         - apiGroups:
-          - rbac.authorization.k8s.io
+            - rbac.authorization.k8s.io
           resources:
-          - clusterroles
-          - clusterrolebindings
+            - clusterroles
+            - clusterrolebindings
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - apps
+            - apps
           resources:
-          - deployments
+            - deployments
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - ""
+            - ""
           resources:
-          - services
-          - serviceaccounts
-          - events
-          - pods
+            - services
+            - serviceaccounts
+            - events
+            - pods
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - route.openshift.io
+            - route.openshift.io
           resources:
-          - routes
+            - routes
           verbs:
-          - '*'
+            - '*'
         - apiGroups:
-          - config.openshift.io
+            - config.openshift.io
           resources:
-          - infrastructures
-          - apiservers
+            - infrastructures
+            - apiservers
           verbs:
-          - get
-          - watch
-          - list
+            - get
+            - watch
+            - list
         serviceAccountName: openshift-cli-manager-operator
       deployments:
-      - name: openshift-cli-manager-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: openshift-cli-manager-operator
-          strategy: {}
-          template:
-            metadata:
-              labels:
+        - name: openshift-cli-manager-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: openshift-cli-manager-operator
-            spec:
-              containers:
-              - args:
-                - operator
-                command:
-                - cli-manager-operator
-                env:
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: OPERATOR_NAME
-                  value: openshift-cli-manager-operator
-                - name: RELATED_IMAGE_OPERAND_IMAGE
-                  value: quay.io/openshift/origin-cli-manager:latest
-                image: quay.io/openshift/origin-cli-manager-operator:latest
-                imagePullPolicy: Always
-                name: openshift-cli-manager-operator
-                ports:
-                - containerPort: 60000
-                  name: metrics
-                resources: {}
-              serviceAccountName: openshift-cli-manager-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: openshift-cli-manager-operator
+              spec:
+                containers:
+                  - args:
+                      - operator
+                    command:
+                      - cli-manager-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: OPERATOR_NAME
+                        value: openshift-cli-manager-operator
+                      - name: RELATED_IMAGE_OPERAND_IMAGE
+                        value: quay.io/openshift/origin-cli-manager:latest
+                    image: quay.io/openshift/origin-cli-manager-operator:latest
+                    imagePullPolicy: Always
+                    name: openshift-cli-manager-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    resources: {}
+                serviceAccountName: openshift-cli-manager-operator
     strategy: deployment
 


### PR DESCRIPTION
Currently, we are replacing operand image in operator image. However, operand image is injected by bundle image. This PR replaces operand and operator image in bundle image. 
Additionally, this PR adds `replicasets` in cluster role permissions as well as some minor improvements in csv file.