### PR TITLE
WRKLDS-1309: Add snyk secret to run sast-snyk-check job

### DIFF
--- a/.tekton/cli-manager-operator-bundle-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-pull-request.yaml
@@ -122,6 +122,9 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "snyk-secret"
+      description: Snyk Token Secret Name
+      name: snyk-secret
     results:
     - description: ""
       name: IMAGE_URL

--- a/.tekton/cli-manager-operator-bundle-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-push.yaml
@@ -119,6 +119,9 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "snyk-secret"
+      description: Snyk Token Secret Name
+      name: snyk-secret
     results:
     - description: ""
       name: IMAGE_URL

--- a/.tekton/cli-manager-operator-pull-request.yaml
+++ b/.tekton/cli-manager-operator-pull-request.yaml
@@ -122,6 +122,9 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "snyk-secret"
+      description: Snyk Token Secret Name
+      name: snyk-secret
     results:
     - description: ""
       name: IMAGE_URL

--- a/.tekton/cli-manager-operator-push.yaml
+++ b/.tekton/cli-manager-operator-push.yaml
@@ -119,6 +119,9 @@ spec:
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
+    - default: "snyk-secret"
+      description: Snyk Token Secret Name
+      name: snyk-secret
     results:
     - description: ""
       name: IMAGE_URL


### PR DESCRIPTION
This PR defines snyk-secret to run sast-snyk-check job which is required for releasing in Konflux.