### PR TITLE
WRKLDS-1421: Add default for To and make Bin as optional

### DIFF
--- a/.tekton/cli-manager-operator-pull-request.yaml
+++ b/.tekton/cli-manager-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-pull-request.yaml".pathChanged() || "bindata/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
+      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-pull-request.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cli-manager-operator

--- a/.tekton/cli-manager-operator-push.yaml
+++ b/.tekton/cli-manager-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-push.yaml".pathChanged() || "bindata/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
+      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-push.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cli-manager-operator

--- a/deploy/02_config.openshift.io_plugins.yaml
+++ b/deploy/02_config.openshift.io_plugins.yaml
@@ -59,6 +59,7 @@ spec:
                           Bin specifies the path to the plugin executable.
                           The path is relative to the root of the installation folder.
                           The binary will be linked after all FileOperations are executed.
+                          If not specified, the first From item in the Files is set.
                         type: string
                       files:
                         description: Files is a list of file locations within the image
@@ -74,9 +75,12 @@ spec:
                                 Directories and wildcards are not currently supported.
                               type: string
                             to:
-                              description: To is the relative path within the root of
+                              description: |-
+                                To is the relative path within the root of
                                 the installation folder to place the file.
+                                Default is set to "." where points the default Krew directory.
                               type: string
+                              default: "."
                           required:
                             - from
                             - to
@@ -94,7 +98,6 @@ spec:
                           darwin/amd64, windows/amd64).
                         type: string
                     required:
-                      - bin
                       - files
                       - image
                       - platform

--- a/test/e2e/bindata/assets/02_config.openshift.io_plugins.yaml
+++ b/test/e2e/bindata/assets/02_config.openshift.io_plugins.yaml
@@ -59,6 +59,7 @@ spec:
                           Bin specifies the path to the plugin executable.
                           The path is relative to the root of the installation folder.
                           The binary will be linked after all FileOperations are executed.
+                          If not specified, the first From item in the Files is set.
                         type: string
                       files:
                         description: Files is a list of file locations within the image
@@ -74,9 +75,12 @@ spec:
                                 Directories and wildcards are not currently supported.
                               type: string
                             to:
-                              description: To is the relative path within the root of
+                              description: |-
+                                To is the relative path within the root of
                                 the installation folder to place the file.
+                                Default is set to "." where points the default Krew directory.
                               type: string
+                              default: "."
                           required:
                             - from
                             - to
@@ -94,7 +98,6 @@ spec:
                           darwin/amd64, windows/amd64).
                         type: string
                     required:
-                      - bin
                       - files
                       - image
                       - platform


### PR DESCRIPTION
To field in Plugin can be defaulted to . where points the default location of Krew. Bin field is no longer required because it can be set to the value of first From field.