### PR TITLE
WRKLDS-1421: Serve metrics server in https 

### DIFF
--- a/bindata/assets/cli-manager/deployment.yaml
+++ b/bindata/assets/cli-manager/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           ports:
             - containerPort: 9449
               protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
           volumeMounts:
             - mountPath: "/etc/secrets"
               name: certs-dir

--- a/bindata/assets/cli-manager/service.yaml
+++ b/bindata/assets/cli-manager/service.yaml
@@ -20,3 +20,25 @@ spec:
     app: openshift-cli-manager
   sessionAffinity: None
   type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    service.beta.openshift.io/serving-cert-secret-name: openshift-cli-manager-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+  labels:
+    app: openshift-cli-manager
+  name: openshift-cli-manager-metrics
+  namespace: openshift-cli-manager-operator
+spec:
+  clusterIP: None
+  ports:
+    - port: 8443
+      protocol: TCP
+      targetPort: 8443
+      name: cli-manager-metrics-port
+  selector:
+    app: openshift-cli-manager

--- a/bindata/assets/cli-manager/servicemonitor.yaml
+++ b/bindata/assets/cli-manager/servicemonitor.yaml
@@ -6,11 +6,19 @@ metadata:
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 60s
+      interval: 30s
       path: /metrics
-      port: cli-manager-port
-      scheme: http
+      port: cli-manager-metrics-port
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: metrics.openshift-cli-manager-operator.svc
   jobLabel: component
   selector:
+    namespaceSelector:
+      matchNames:
+        - openshift-cli-manager-operator
     matchLabels:
       app: openshift-cli-manager


### PR DESCRIPTION
This PR is complementary of this https://github.com/openshift/cli-manager/pull/92 as operator actually applies the resource configurations.