### PR TITLE
WRKLDS-1421: Prepare tekton files specific to release-4.17 branch

### DIFF
--- a/.tekton/cli-manager-operator-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-operator-4-17-pull-request.yaml
@@ -4,16 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cli-manager-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-bundle-push.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
+      event == "pull_request" && target_branch == "release-4.17" && (".tekton/cli-manager-operator-4-17-pull-request.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager-operator-bundle
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-operator-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-operator-bundle-on-push
+  name: cli-manager-operator-4-17-on-pull-request
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:
@@ -22,9 +23,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
-    value: bundle.Dockerfile
+    value: Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/cli-manager-operator-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-operator-4-17-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-operator-4-17:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/cli-manager-operator-4-17-push.yaml
+++ b/.tekton/cli-manager-operator-4-17-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && target_branch == "main" && (".tekton/cli-manager-operator-push.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
+      event == "push" && target_branch == "release-4.17" && (".tekton/cli-manager-operator-4-17-push.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager-operator
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-operator-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-operator-on-push
+  name: cli-manager-operator-4-17-on-push
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:

--- a/.tekton/cli-manager-operator-4-17-push.yaml
+++ b/.tekton/cli-manager-operator-4-17-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-operator-4-17:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/cli-manager-operator-bundle-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-4-17-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-bundle-pull-request.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
+      event == "pull_request" && target_branch == "release-4.17" && (".tekton/cli-manager-operator-bundle-4-17-pull-request.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager-operator-bundle
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-operator-bundle-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-operator-bundle-on-pull-request
+  name: cli-manager-operator-bundle-4-17-on-pull-request
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:

--- a/.tekton/cli-manager-operator-bundle-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-4-17-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator-bundle:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-operator-bundle-4-17:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/cli-manager-operator-bundle-4-17-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-4-17-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cli-manager-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-operator-pull-request.yaml".pathChanged() || "bindata/***".pathChanged() || "deploy/***".pathChanged() || "***/*.go".pathChanged() || "Dockerfile".pathChanged() || "***/go.*".pathChanged() )
+      event == "push" && target_branch == "release-4.17" && (".tekton/cli-manager-operator-bundle-4-17-push.yaml".pathChanged() || "metadata/***".pathChanged() || "manifests/***".pathChanged() || "bundle.Dockerfile".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager-operator
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-operator-bundle-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-operator-on-pull-request
+  name: cli-manager-operator-bundle-4-17-on-push
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:
@@ -23,11 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator-bundle:{{revision}}
   - name: dockerfile
-    value: Dockerfile
+    value: bundle.Dockerfile
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/cli-manager-operator-bundle-4-17-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-4-17-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-operator-bundle-4-17:{{revision}}
   - name: dockerfile
     value: bundle.Dockerfile
   pipelineSpec:

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,7 +2,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as bui
 WORKDIR /go/src/github.com/openshift/cli-manager-operator
 COPY . .
 
-ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:02058408dfb534a877f6cc0be07a1615dfc7fad212a699c2d1471f36c459f2c9
+ARG OPERAND_IMAGE=registry.redhat.io/cli-manager-operator/cli-manager-rhel9@sha256:4e81f6727f9a91901142644acb39a698d6d7365d41436cadbfb31d389181f912
 ARG REPLACED_OPERAND_IMG=quay.io/openshift/origin-cli-manager:latest
 
 # Replace the operand image in deploy/07_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.


### PR DESCRIPTION
release-4.17 branch cut has been performed and there is no more mirroring from main branch. We can update release-4.17 branch for Konflux accordingly.