### PR TITLE
WRKLDS-1421: Separate metrics service into own file to apply in targetconfig observer

### DIFF
--- a/bindata/assets/cli-manager/deployment.yaml
+++ b/bindata/assets/cli-manager/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           ports:
             - containerPort: 9449
               protocol: TCP
-            - containerPort: 8443
+            - containerPort: 60000
               protocol: TCP
           volumeMounts:
             - mountPath: "/etc/secrets"

--- a/bindata/assets/cli-manager/servicemetrics.yaml
+++ b/bindata/assets/cli-manager/servicemetrics.yaml
@@ -8,15 +8,14 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: openshift-cli-manager
-  name: openshift-cli-manager
+  name: openshift-cli-manager-metrics
   namespace: openshift-cli-manager-operator
 spec:
+  clusterIP: None
   ports:
-    - name: cli-manager-port
-      port: 9449
+    - port: 60000
       protocol: TCP
-      targetPort: 9449
+      targetPort: 60000
+      name: cli-manager-metrics-port
   selector:
     app: openshift-cli-manager
-  sessionAffinity: None
-  type: ClusterIP

--- a/bindata/assets/cli-manager/servicemonitor.yaml
+++ b/bindata/assets/cli-manager/servicemonitor.yaml
@@ -17,8 +17,5 @@ spec:
         serverName: metrics.openshift-cli-manager-operator.svc
   jobLabel: component
   selector:
-    namespaceSelector:
-      matchNames:
-        - openshift-cli-manager-operator
     matchLabels:
       app: openshift-cli-manager


### PR DESCRIPTION
Targetconfig observer expects to apply one resource in each yaml file. That's why, this PR separates metrics service resource to it's own file to apply. 