### PR TITLE
WRKLDS-1421: Add cluster-monitoring annotation in namespace

### DIFF
--- a/deploy/01_namespace.yaml
+++ b/deploy/01_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-cli-manager-operator

--- a/test/e2e/bindata/assets/01_namespace.yaml
+++ b/test/e2e/bindata/assets/01_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-cli-manager-operator


### PR DESCRIPTION
Without this annotation in openshift-cli-manager-operator namespace, prometheus rejects to collect metrics.