### PR TITLE
OCPBUGS-39351: Add status subresource for climanager CRD

### DIFF
--- a/deploy/00_cli-manager-operator.crd.yaml
+++ b/deploy/00_cli-manager-operator.crd.yaml
@@ -164,3 +164,11 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/openshift-cli-manager-operator.crd.yaml
+++ b/manifests/openshift-cli-manager-operator.crd.yaml
@@ -164,3 +164,11 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/e2e/bindata/assets/00_cli-manager-operator.crd.yaml
+++ b/test/e2e/bindata/assets/00_cli-manager-operator.crd.yaml
@@ -164,3 +164,11 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
In order to update the status of climanager CRD, we need to define status subresource in the CRD definition. Otherwise, we get periodic not found errors during the update. This PR fixes this.