### PR TITLE
OCPBUGS-41512: Set readOnlyRootFilesystem to true for operator and operand

### DIFF
--- a/bindata/assets/cli-manager/deployment.yaml
+++ b/bindata/assets/cli-manager/deployment.yaml
@@ -29,11 +29,14 @@ spec:
           emptyDir: {}
         - name: krew-git
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       restartPolicy: "Always"
       containers:
         - name: "cli-manager"
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: ${IMAGE}
@@ -54,5 +57,7 @@ spec:
               mountPath: "/var/run/plugins"
             - name: krew-git
               mountPath: "/var/run/git"
+            - name: tmp
+              mountPath: "/tmp"
       serviceAccountName: "openshift-cli-manager"
       terminationGracePeriodSeconds: 10

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -13,9 +13,21 @@ spec:
       labels:
         name: openshift-cli-manager-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: openshift-cli-manager-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/openshift/origin-cli-manager-operator:latest
+          volumeMounts:
+            - name: tmp
+              mountPath: "/tmp"
           ports:
             - containerPort: 60000
               name: metrics
@@ -34,3 +46,6 @@ spec:
             - name: RELATED_IMAGE_OPERAND_IMAGE
               value: quay.io/openshift/origin-cli-manager:latest
       serviceAccountName: openshift-cli-manager-operator
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ spec:
   installModes:
     - supported: true
       type: OwnNamespace
-    - supported: false
+    - supported: true
       type: SingleNamespace
     - supported: false
       type: MultiNamespace
@@ -234,6 +234,10 @@ spec:
                 labels:
                   name: openshift-cli-manager-operator
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - args:
                       - operator
@@ -249,6 +253,14 @@ spec:
                       - name: RELATED_IMAGE_OPERAND_IMAGE
                         value: quay.io/openshift/origin-cli-manager:latest
                     image: quay.io/openshift/origin-cli-manager-operator:latest
+                    volumeMounts:
+                      - name: tmp
+                        mountPath: "/tmp"
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop: [ "ALL" ]
                     imagePullPolicy: Always
                     name: openshift-cli-manager-operator
                     ports:
@@ -256,5 +268,8 @@ spec:
                         name: metrics
                     resources: {}
                 serviceAccountName: openshift-cli-manager-operator
+                volumes:
+                  - name: tmp
+                    emptyDir: {}
     strategy: deployment
 

--- a/test/e2e/bindata/assets/06_deployment.yaml
+++ b/test/e2e/bindata/assets/06_deployment.yaml
@@ -13,10 +13,15 @@ spec:
       labels:
         name: openshift-cli-manager-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: openshift-cli-manager-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: [ "ALL" ]
           resources:
@@ -24,6 +29,9 @@ spec:
               memory: 50Mi
               cpu: 10m
           image: # set in e2e
+          volumeMounts:
+            - name: tmp
+              mountPath: "/tmp"
           ports:
             - containerPort: 60000
               name: metrics
@@ -43,3 +51,6 @@ spec:
             - name: RELATED_IMAGE_OPERAND_IMAGE
               value: # set in e2e
       serviceAccountName: openshift-cli-manager-operator
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
This PR sets `readOnlyRootFilesystem` to true for cli manager operator and operand in addition to adding restricted securitycontext configurations for cli manager operator deployment.