### PR TITLE
WRKLDS-1491: Add multi arch FBC support back again

### DIFF
--- a/.tekton/cli-manager-operator-fbc-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-operator-fbc-4-17-pull-request.yaml
@@ -29,12 +29,18 @@ spec:
       value: catalog.Dockerfile
     - name: path-context
       value: v4.17
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
   pipelineSpec:
     finally:
       - name: show-sbom
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
         taskRef:
           params:
             - name: name
@@ -44,28 +50,6 @@ spec:
             - name: kind
               value: task
           resolver: bundles
-      - name: show-summary
-        params:
-          - name: pipelinerun-name
-            value: $(context.pipelineRun.name)
-          - name: git-url
-            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-          - name: image-url
-            value: $(params.output-image)
-          - name: build-task-status
-            value: $(tasks.build-container.status)
-        taskRef:
-          params:
-            - name: name
-              value: summary
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
     params:
       - description: Source Repository URL
         name: git-url
@@ -95,17 +79,13 @@ spec:
         description: Skip checks against built image
         name: skip-checks
         type: string
-      - default: "false"
+      - default: "true"
         description: Execute the build with network isolation
         name: hermetic
         type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
-        type: string
-      - default: "false"
-        description: Java build
-        name: java
         type: string
       - default: ""
         description: Image tag expiration time, time values could be something like
@@ -115,13 +95,26 @@ spec:
         description: Build a source image.
         name: build-source-image
         type: string
+      - default: "true"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default:
+          - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
     results:
       - description: ""
         name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - description: ""
         name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - description: ""
         name: CHAINS-GIT_URL
         value: $(tasks.clone-repository.results.url)
@@ -152,14 +145,18 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - init
         taskRef:
           params:
             - name: name
-              value: git-clone
+              value: git-clone-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:049b34d2c6b148f6754510bd0ac39872605372925f591109d7508eeafffb3333
             - name: kind
               value: task
           resolver: bundles
@@ -169,11 +166,14 @@ spec:
             values:
               - "true"
         workspaces:
-          - name: output
-            workspace: workspace
           - name: basic-auth
             workspace: git-auth
-      - name: build-container
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -187,14 +187,18 @@ spec:
             value: $(params.image-expires-after)
           - name: COMMIT_SHA
             value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
         runAfter:
           - clone-repository
         taskRef:
           params:
             - name: name
-              value: buildah
+              value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:71d3bb81d1c7c9f99946b5f1d4844664f2036636fd114cf5232db644bc088981
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:77c38532a46d7bd8c5da9f4eac0f2d3e5402b8d4445dfe36781050270fec8c0f
             - name: kind
               value: task
           resolver: bundles
@@ -203,23 +207,49 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: source
-            workspace: workspace
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-images.results.IMAGE_REF[*])
+        runAfter:
+          - build-images
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:8619eabd7cf3340d1123afadac1f4296dc14472c8db0f774497748c762f46f33
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
       - name: deprecated-base-image-check
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
               value: deprecated-image-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:d1836ac902bea0cd7aad61201434f03fc0cdea29e212604dce180e0eef620ba6
+              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:592bbced9d8529c5391ecd3464a2276d25946514fe0b4fd91f2cdbe5730aa732
             - name: kind
               value: task
           resolver: bundles
@@ -231,9 +261,9 @@ spec:
       - name: apply-tags
         params:
           - name: IMAGE
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
@@ -246,17 +276,17 @@ spec:
       - name: inspect-image
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
               value: inspect-image
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.1@sha256:c8d7616fba1533637547eccd598314721a106ec0d108dcb5162e234d5d90c755
+              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.1@sha256:926d1cc474e48e8bf1beb35237cf2e69c35e3fc474ea57ad24aed62dc536a1b8
             - name: kind
               value: task
           resolver: bundles
@@ -271,9 +301,9 @@ spec:
       - name: fbc-validate
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: BASE_IMAGE
             value: $(tasks.inspect-image.results.BASE_IMAGE)
         runAfter:
@@ -283,7 +313,7 @@ spec:
             - name: name
               value: fbc-validation
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.1@sha256:609412569e14e25cc4a1f9430fe1c464c5e2bf9ff0b1ce3894a194ad288ca541
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.1@sha256:90d04c77dfa0c97c3133c6d96d38ab31609d1d4872086f9328d7c33a04f599ad
             - name: kind
               value: task
           resolver: bundles
@@ -303,7 +333,7 @@ spec:
             - name: name
               value: fbc-related-image-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.1@sha256:0fae84cc832d21c250334ab1d285db92e7e22e916ea342d044e46136c502d2f8
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.1@sha256:682f479a262d52392f9e1cf25784c846d7fcfeb5a1461798f3fc418200c0f8e1
             - name: kind
               value: task
           resolver: bundles
@@ -318,6 +348,8 @@ spec:
     workspaces:
       - name: workspace
       - name: git-auth
+        optional: true
+      - name: netrc
         optional: true
   taskRunTemplate: {}
   workspaces:

--- a/.tekton/cli-manager-operator-fbc-4-17-push.yaml
+++ b/.tekton/cli-manager-operator-fbc-4-17-push.yaml
@@ -26,12 +26,18 @@ spec:
       value: catalog.Dockerfile
     - name: path-context
       value: v4.17
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
   pipelineSpec:
     finally:
       - name: show-sbom
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
         taskRef:
           params:
             - name: name
@@ -41,28 +47,6 @@ spec:
             - name: kind
               value: task
           resolver: bundles
-      - name: show-summary
-        params:
-          - name: pipelinerun-name
-            value: $(context.pipelineRun.name)
-          - name: git-url
-            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-          - name: image-url
-            value: $(params.output-image)
-          - name: build-task-status
-            value: $(tasks.build-container.status)
-        taskRef:
-          params:
-            - name: name
-              value: summary
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
     params:
       - description: Source Repository URL
         name: git-url
@@ -100,10 +84,6 @@ spec:
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
         type: string
-      - default: "false"
-        description: Java build
-        name: java
-        type: string
       - default: ""
         description: Image tag expiration time, time values could be something like
           1h, 2d, 3w for hours, days, and weeks, respectively.
@@ -112,13 +92,26 @@ spec:
         description: Build a source image.
         name: build-source-image
         type: string
+      - default: "true"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default:
+          - linux/x86_64
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
     results:
       - description: ""
         name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - description: ""
         name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - description: ""
         name: CHAINS-GIT_URL
         value: $(tasks.clone-repository.results.url)
@@ -149,14 +142,18 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - init
         taskRef:
           params:
             - name: name
-              value: git-clone
+              value: git-clone-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:049b34d2c6b148f6754510bd0ac39872605372925f591109d7508eeafffb3333
             - name: kind
               value: task
           resolver: bundles
@@ -166,11 +163,14 @@ spec:
             values:
               - "true"
         workspaces:
-          - name: output
-            workspace: workspace
           - name: basic-auth
             workspace: git-auth
-      - name: build-container
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -184,14 +184,18 @@ spec:
             value: $(params.image-expires-after)
           - name: COMMIT_SHA
             value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
         runAfter:
           - clone-repository
         taskRef:
           params:
             - name: name
-              value: buildah
+              value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:71d3bb81d1c7c9f99946b5f1d4844664f2036636fd114cf5232db644bc088981
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:77c38532a46d7bd8c5da9f4eac0f2d3e5402b8d4445dfe36781050270fec8c0f
             - name: kind
               value: task
           resolver: bundles
@@ -200,23 +204,49 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: source
-            workspace: workspace
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-images.results.IMAGE_REF[*])
+        runAfter:
+          - build-images
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:8619eabd7cf3340d1123afadac1f4296dc14472c8db0f774497748c762f46f33
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(tasks.init.results.build)
+            operator: in
+            values:
+              - "true"
       - name: deprecated-base-image-check
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
               value: deprecated-image-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:d1836ac902bea0cd7aad61201434f03fc0cdea29e212604dce180e0eef620ba6
+              value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:592bbced9d8529c5391ecd3464a2276d25946514fe0b4fd91f2cdbe5730aa732
             - name: kind
               value: task
           resolver: bundles
@@ -228,9 +258,9 @@ spec:
       - name: apply-tags
         params:
           - name: IMAGE
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
@@ -243,17 +273,17 @@ spec:
       - name: inspect-image
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         runAfter:
-          - build-container
+          - build-image-index
         taskRef:
           params:
             - name: name
               value: inspect-image
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.1@sha256:c8d7616fba1533637547eccd598314721a106ec0d108dcb5162e234d5d90c755
+              value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.1@sha256:926d1cc474e48e8bf1beb35237cf2e69c35e3fc474ea57ad24aed62dc536a1b8
             - name: kind
               value: task
           resolver: bundles
@@ -268,9 +298,9 @@ spec:
       - name: fbc-validate
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-container.results.IMAGE_DIGEST)
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: BASE_IMAGE
             value: $(tasks.inspect-image.results.BASE_IMAGE)
         runAfter:
@@ -280,7 +310,7 @@ spec:
             - name: name
               value: fbc-validation
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.1@sha256:609412569e14e25cc4a1f9430fe1c464c5e2bf9ff0b1ce3894a194ad288ca541
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.1@sha256:90d04c77dfa0c97c3133c6d96d38ab31609d1d4872086f9328d7c33a04f599ad
             - name: kind
               value: task
           resolver: bundles
@@ -300,7 +330,7 @@ spec:
             - name: name
               value: fbc-related-image-check
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.1@sha256:0fae84cc832d21c250334ab1d285db92e7e22e916ea342d044e46136c502d2f8
+              value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.1@sha256:682f479a262d52392f9e1cf25784c846d7fcfeb5a1461798f3fc418200c0f8e1
             - name: kind
               value: task
           resolver: bundles
@@ -315,6 +345,8 @@ spec:
     workspaces:
       - name: workspace
       - name: git-auth
+        optional: true
+      - name: netrc
         optional: true
   taskRunTemplate: {}
   workspaces:


### PR DESCRIPTION
This PR switches back to multi arch of FBC that was reverted in https://github.com/openshift/cli-manager-operator/pull/337.