### PR TITLE
NO-JIRA: Add required rpms-signature-scan task in tekton

### DIFF
--- a/.tekton/cli-manager-operator-bundle-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-pull-request.yaml
@@ -455,6 +455,9 @@ spec:
           - name: kind
             value: task
         resolver: bundles
+      workspaces:
+        - name: workspace
+          workspace: workspace
     - name: rpms-signature-scan
       params:
         - name: image-digest

--- a/.tekton/cli-manager-operator-bundle-pull-request.yaml
+++ b/.tekton/cli-manager-operator-bundle-pull-request.yaml
@@ -455,9 +455,23 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
+    - name: rpms-signature-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/cli-manager-operator-bundle-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-push.yaml
@@ -452,6 +452,9 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      workspaces:
+        - name: workspace
+          workspace: workspace
     - name: rpms-signature-scan
       params:
         - name: image-digest

--- a/.tekton/cli-manager-operator-bundle-push.yaml
+++ b/.tekton/cli-manager-operator-bundle-push.yaml
@@ -452,9 +452,23 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
+    - name: rpms-signature-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+        - build-container
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/cli-manager-operator-pull-request.yaml
+++ b/.tekton/cli-manager-operator-pull-request.yaml
@@ -460,6 +460,28 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/cli-manager-operator-push.yaml
+++ b/.tekton/cli-manager-operator-push.yaml
@@ -457,6 +457,28 @@ spec:
           - name: kind
             value: task
           resolver: bundles
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     workspaces:
     - name: git-auth
       optional: true


### PR DESCRIPTION
`rpms-signature-scan` will be mandatory soon and this PR adds this.