### PR TITLE
Fix typo in OLM categories: OpenShift Optional

### DIFF
--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
       enhancing your OpenShift command-line experience.
     repository: https://github.com/openshift/cli-manager-operator
     support: Red Hat, Inc.
-    categories: Openshift Optional
+    categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"


### PR DESCRIPTION
Fixes https://github.com/openshift/cli-manager-operator/issues/694

This operator creates a category only for itself:
![image](https://github.com/user-attachments/assets/1d90374e-a5ed-4674-89a4-697fd9ddbd15)
