### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cli-manager-operator-4-17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY --from=builder /go/src/github.com/openshift/cli-manager-operator/LICENSE /l
 
 LABEL com.redhat.component="CLI Manager"
 LABEL description="The CLI Manager is a comprehensive tool designed to simplify the management of OpenShift CLI plugins within the OpenShift environment. Modeled after the popular krew plugin manager, it offers seamless integration, easy installation, and efficient handling of a wide array of plugins, enhancing your OpenShift command-line experience."
-LABEL name="cli-manager-operator"
+LABEL name="cli-manager-operator/cli-manager-rhel9-operator"
+LABEL cpe="cpe:/a:redhat:cli_manager_operator:0.1::el9"
 LABEL summary="The CLI Manager is a comprehensive tool designed to simplify the management of OpenShift CLI plugins within the OpenShift environment. Modeled after the popular krew plugin manager, it offers seamless integration, easy installation, and efficient handling of a wide array of plugins, enhancing your OpenShift command-line experience."
 LABEL io.k8s.display-name="CLI Manager Operator" \
       io.k8s.description="This is an operator to manage CLI Manager" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
