### PR TITLE
[WIP] Add required-scc annotation to pod templates

### DIFF
--- a/bindata/assets/cli-manager/deployment.yaml
+++ b/bindata/assets/cli-manager/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: cli-manager
+        openshift.io/required-scc: restricted-v2
       labels:
         app: "openshift-cli-manager"
     spec:

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -10,6 +10,8 @@ spec:
       name: openshift-cli-manager-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: openshift-cli-manager-operator
     spec:

--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -241,6 +241,8 @@ spec:
             strategy: {}
             template:
               metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   name: openshift-cli-manager-operator
               spec:

--- a/test/e2e/bindata/assets/06_deployment.yaml
+++ b/test/e2e/bindata/assets/06_deployment.yaml
@@ -10,6 +10,8 @@ spec:
       name: openshift-cli-manager-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: openshift-cli-manager-operator
     spec:


### PR DESCRIPTION
Hi Team,

Failure logs:
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/79856/rehearse-79856-pull-ci-openshift-cli-manager-operator-main-e2e-aws-operator-serial-ote/2060261750510456832
```

Add 'openshift.io/required-scc: restricted-v2' annotation to all deployment pod templates for both the operator and the managed cli-manager to comply with OpenShift security requirements.

This fixes the CI test failure:
[Monitor:required-scc-annotation-checker][sig-auth] all workloads in ns/openshift-cli-manager-operator must set the 'openshift.io/required-scc' annotation

Files updated:
- deploy/07_deployment.yaml (operator deployment)
- bindata/assets/cli-manager/deployment.yaml (managed cli-manager)
- manifests/cli-manager-operator.clusterserviceversion.yaml (CSV)
- test/e2e/bindata/assets/06_deployment.yaml (e2e test deployment)