### PR TITLE
CNTRLPLANE-3725: docs: add AGENTS.md, ARCHITECTURE.md, and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# CLI Manager Operator
+
+An OpenShift operator that manages the [CLI Manager](https://github.com/openshift/cli-manager) operand, which distributes CLI tools and kubectl plugins to cluster users via [krew](https://krew.sigs.k8s.io/). Built on the [library-go](https://github.com/openshift/library-go) controller framework, it watches a singleton `CliManager` custom resource and reconciles a Deployment, Route, Service, RBAC, and ServiceMonitor for the operand. Installed by the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full design and data flow.
+
+## Build and Test
+
+```bash
+make build          # Build all binaries (operator + OTE test runner)
+make test-unit      # Unit tests (./pkg/... ./cmd/...) — alias: make test
+make verify         # Formatting, vetting, golang version checks
+make test-e2e       # E2E operator tests (3h timeout, requires cluster)
+```
+
+Go version: see `go.mod`.
+
+## Project Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `cmd/cli-manager-operator/` | Operator binary entry point (`operator` subcommand) |
+| `cmd/cli-manager-operator-testing/` | Testing variant that enables insecure HTTP artifact serving |
+| `cmd/cli-manager-operator-tests-ext/` | OTE test runner entry point |
+| `pkg/operator/starter.go` | Operator initialization — creates clients, informers, and starts controllers |
+| `pkg/operator/target_config_reconciler.go` | Main reconciliation loop — manages all operand resources |
+| `pkg/operator/operatorclient/` | Namespace constants and operator client interfaces |
+| `pkg/apis/climanager/v1/` | `CliManager` CRD type definitions |
+| `pkg/generated/` | Generated clientsets, informers, listers for the CliManager CRD |
+| `pkg/cmd/operator/` | Cobra command factory for the `operator` subcommand |
+| `pkg/version/` | Build version info and Prometheus build_info metric |
+| `bindata/assets/cli-manager/` | Embedded operand manifests (Deployment, Service, Route, RBAC, ServiceMonitor) |
+| `manifests/` | CVO deployment manifests (CRD, CSV) |
+| `deploy/` | Quick-start manifests for direct deployment (CRD, namespace, RBAC, operator Deployment, CR) |
+| `test/e2e/` | E2E test suite (deploys operator, creates Plugin CR, validates krew install) |
+
+## Controller Pattern
+
+The operator has two controllers wired in `pkg/operator/starter.go` via `RunOperator()`:
+
+1. **`TargetConfigReconciler`** — the main reconciliation loop. Watches the singleton `CliManager` CR (name `cluster`, namespace `openshift-cli-manager-operator`) and reconciles all operand resources on every add/update/delete event.
+2. **`ClusterOperatorLoggingController`** — a library-go controller that watches the CR's `logLevel`/`operatorLogLevel` fields and dynamically adjusts klog verbosity at runtime.
+
+The reconciler uses `resourceapply` from library-go for idempotent resource management: it reads embedded YAML assets from `bindata/`, substitutes the operand image placeholder (`${IMAGE}`), applies log-level flags, and applies each resource.
+
+## Key Conventions
+
+- **Namespace:** everything runs in `openshift-cli-manager-operator`. `OperandName = "openshift-cli-manager"` is a resource name prefix, not a separate namespace. Constants in `pkg/operator/operatorclient/interfaces.go`.
+- **Singleton CR:** The operator watches a single `CliManager` CR named `cluster`.
+- **Operand image:** Injected via the `RELATED_IMAGE_OPERAND_IMAGE` environment variable on the operator Deployment.
+- **Logging:** `k8s.io/klog/v2` with verbosity levels. Log level from CR spec: Normal→`-v=2`, Debug→`-v=4`, Trace→`-v=6`, TraceAll→`-v=8`.
+- **Error handling:** wrap with `fmt.Errorf("context: %w", err)`.
+- **Build flags:** `-tags strictfipsruntime` (FIPS compliance).
+- **Upstream changes:** controller framework fixes should go to [library-go](https://github.com/openshift/library-go), not here. CRD type changes go to `pkg/apis/` in this repo, then regenerate clients with `hack/update-codegen.sh` (uses `k8s.io/code-generator`).
+
+## Non-Obvious Internals
+
+- **`controllercmd` intermediary:** The entry point chain (`cmd/` → `pkg/cmd/operator/cmd.go` → `pkg/operator/starter.go`) passes through library-go's `controllercmd.ControllerCommandConfig`, which handles leader election, signal handling, health checks, and serving info. None of this is visible in the operator code itself.
+- **Adding a new operand resource:** Requires two steps: (1) add the YAML manifest under `bindata/assets/cli-manager/`, and (2) add a corresponding `manage*` method + call in the `sync()` method of `target_config_reconciler.go`. The `resourceapply` helpers do read-modify-write with last-applied annotation tracking.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines. Key rules:
+
+- Do not modify files under `vendor/`. Use `go mod tidy && go mod vendor`.
+- `bindata/assets.go` is generated — update the YAML files under `bindata/assets/`, not this file.
+- Write unit tests for every change. E2E tests for significant features.
+
+## Testing
+
+- **Unit tests:** co-located `*_test.go` files, table-driven, `make test` or `go test ./pkg/... ./cmd/...`
+- **E2E tests:** `test/e2e/` — deploys the operator to a real cluster, creates a Plugin CR, installs it via krew, and verifies execution.
+- **OTE framework:** `cli-manager-operator-tests-ext` binary. See [CONTRIBUTING.md](CONTRIBUTING.md#openshift-tests-extension-ote) for usage.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Architecture
+
+## Overview
+
+The CLI Manager Operator is an OpenShift operator that manages the [CLI Manager](https://github.com/openshift/cli-manager) operand — a service that distributes CLI tools and kubectl plugins to cluster users via [krew](https://krew.sigs.k8s.io/). It is deployed by the Cluster Version Operator (CVO) and uses the [library-go](https://github.com/openshift/library-go) controller framework.
+
+The operator's primary responsibilities:
+- Watch the singleton `CliManager` custom resource for desired state
+- Reconcile operand resources: Deployment, Route, Service, RBAC, ServiceMonitor
+- Inject the operand container image and log-level configuration
+- Report status via operator conditions and generation tracking
+
+## Data Flow
+
+```text
+  CliManager CR (operator.openshift.io/v1)
+  (name: "cluster", ns: openshift-cli-manager-operator)
+              │
+              ▼
+  ┌──────────────────────────────────────────────────┐
+  │         TargetConfigReconciler                    │
+  │  (watches CR, reads embedded YAML assets,         │
+  │   substitutes image + log level, applies all      │
+  │   operand resources via resourceapply)             │
+  └──────────────────────┬───────────────────────────┘
+                         │
+      ┌──────────────────┼──────────────────┐
+      ▼                  ▼                  ▼
+  Deployment        Route + Service      RBAC
+  (cli-manager      (TLS edge,           (ClusterRole,
+   2 replicas)       /cli-manager)        ServiceAccount)
+      │
+      ▼
+  CLI Manager pods
+  (serve plugins via krew index)
+```
+
+Users interact with the operand through the `oc krew` command, which fetches plugin metadata from the Route and installs CLI tools.
+
+## Operator Startup
+
+Entry point: `cmd/cli-manager-operator/main.go` → `pkg/cmd/operator/cmd.go` → `pkg/operator/starter.go:RunOperator()`.
+
+Startup sequence:
+1. Create clients (Kubernetes, dynamic, CliManager, Route)
+2. Create informer factory for the CliManager CRD (10-minute resync)
+3. Create and start `TargetConfigReconciler` and `ClusterOperatorLoggingController`
+4. Block until context cancellation
+
+## Namespace
+
+Everything runs in a single namespace: `openshift-cli-manager-operator` (constant `OperatorNamespace` in `pkg/operator/operatorclient/interfaces.go`). Both the operator Deployment and all operand resources (Deployment, Service, Route, RBAC, ServiceMonitor) live here. The constant `OperandName = "openshift-cli-manager"` is a resource name prefix, not a separate namespace.
+
+## TargetConfigReconciler
+
+`pkg/operator/target_config_reconciler.go` is the single controller. On each sync it:
+
+1. Fetches the `CliManager` CR (`cluster`)
+2. Applies RBAC resources (ClusterRole, ClusterRoleBinding, Role, RoleBinding)
+3. Applies the operand Deployment:
+   - Substitutes `${IMAGE}` with the value of `RELATED_IMAGE_OPERAND_IMAGE`
+   - Sets klog verbosity based on CR `logLevel` (Normal→`-v=2`, Debug→`-v=4`, Trace→`-v=6`, TraceAll→`-v=8`)
+   - Optionally enables `--serve-artifacts-in-http` for testing
+4. Applies networking resources (Route, Service, metrics Service)
+5. Applies the ServiceAccount
+6. Applies the ServiceMonitor for Prometheus scraping
+7. Updates CR status with deployment generation
+
+The reconciler uses a rate-limited work queue. A worker goroutine blocks on the queue and processes items immediately as they arrive; `wait.Until` restarts the worker with a 1-second delay if it exits. Events (add/update/delete) on the `CliManager` CR enqueue a sync.
+
+## Operand Resources
+
+All operand manifests are embedded in `bindata/assets/cli-manager/`:
+
+| Asset | Purpose |
+|-------|---------|
+| `deployment.yaml` | 2-replica Deployment running `cli-manager start`, ports 9449 (service) and 60000 (metrics) |
+| `route.yaml` | TLS edge-terminated Route at path `/cli-manager` with 5-minute HAProxy timeout |
+| `service.yaml` | ClusterIP Service on port 9449 |
+| `servicemetrics.yaml` | Metrics Service on port 60000 |
+| `servicemonitor.yaml` | Prometheus ServiceMonitor |
+| `serviceaccount.yaml` | ServiceAccount for the operand |
+| `clusterrole.yaml` | ClusterRole for CLI Manager |
+| `clusterrolebinding.yaml` | ClusterRoleBinding |
+| `role.yaml` | Namespaced Role |
+| `rolebinding.yaml` | RoleBinding |
+
+The Deployment runs with a restricted-v2 security context and mounts three emptyDir volumes (`krew-plugins`, `krew-git`, `tmp`) plus a cert secret (`certs-dir`).
+
+## Custom Resource
+
+The `CliManager` CRD (`operator.openshift.io/v1`) embeds the standard `OperatorSpec` and `OperatorStatus` from the OpenShift API:
+
+- **Spec fields** (inherited): `managementState`, `logLevel`, `operatorLogLevel`, `observedConfig`, `unsupportedConfigOverrides`
+- **Status fields** (inherited): `conditions`, `generations`, `observedGeneration`, `readyReplicas`, `version`
+
+The CRD is a singleton — the operator expects exactly one instance named `cluster` in the `openshift-cli-manager-operator` namespace.
+
+## Testing Variant
+
+`cmd/cli-manager-operator-testing/` builds an identical operator binary but with `--serve-artifacts-in-http` support (hidden flag). When enabled, the Route uses `InsecureEdgeTerminationPolicy: Allow` instead of `Redirect`, and the operand serves artifacts over HTTP. This exists so e2e tests can fetch artifacts over plain HTTP without dealing with TLS certificate setup in CI.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,217 @@
+# Contributing to the OpenShift Control Plane Components/Repositories
+
+This document serves as a guide for contributing to the OpenShift components/repositories
+that the OpenShift Control Plane group is responsible for maintaining.
+
+This document is explicitly for contributions to individual component repositories and not for high-level
+feature proposals within OpenShift.
+
+Feature proposals should follow the OpenShift Enhancement Proposal process outlined in https://github.com/openshift/enhancements/blob/master/dev-guide/feature-zero-to-hero.md#openshift-feature-development-zero-to-hero-guide.
+If you are looking for a review on an OpenShift Enhancement Proposal that involves changes to components
+maintained by the control plane group, please request a review in the [`#forum-ocp-apiserver`](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel. Requests for review may be redirected to more appropriate and/or more focused channels for discussion.
+
+This document contains the following sections:
+
+- [Code conventions](#code-conventions) - A collection of guidelines, style suggestions, and tips for writing code.
+- [Testing guidelines](#testing-guidelines) - Guidelines and expectations for testing of contributions.
+- [Pull Request process/guidelines](#pull-request-process-and-guidelines) - Guidelines and expectations of pull requests containing contributions.
+- [Review expectations](#review-expectations) - Guidelines and expectations for requesting reviews and interacting with reviewers.
+
+## Code Conventions
+
+We largely follow the [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md#code-conventions).
+
+Review both the Kubernetes Code Conventions and the ones specified here.
+There will be some overlap. If any conventions are at odds with one another, prefer the conventions explicitly documented here.
+
+### Bash
+
+- Follow the [shell styleguide](https://google.github.io/styleguide/shellguide.html).
+- Use [`shellcheck`](https://github.com/koalaman/shellcheck) to identify common mistakes or caveats.
+- Ensure that all scripts run consistently across Linux and macOS.
+
+### Golang (Go)
+
+- Review [Effective Go](https://go.dev/doc/effective_go).
+- Review common [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Review and avoid [Go Landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)
+- Comment your code following the [Go comment conventions](https://go.dev/doc/comment).
+  - Comments should be meaningful and add context and/or explain choices that cannot be expressed through clear code.
+  - All exported types, functions, and methods must have descriptive comments.
+  - All unexported types, functions, and methods should have descriptive comments.
+- When adding command-line flags, use dashes/hyphens (`-`) and not underscores (`_`).
+- Naming
+  - Please consider package name when selecting an interface name, and avoid redundancy. For example, `storage.Interface` is better than `storage.StorageInterface`.
+  - Do not use uppercase characters, underscores, or dashes in package names.
+  - Please consider parent directory name when choosing a package name. For example, `pkg/controllers/autoscaler/foo.go` should say `package autoscaler` not `package autoscalercontroller`.
+    - Unless there's a good reason, the package foo line should match the name of the directory in which the .go file exists.
+    - Importers can use a different name if they need to disambiguate.
+  - Locks should be called `lock` and should never be embedded (always `lock sync.Mutex`). When multiple locks are present, give each lock a distinct name following Go conventions: `stateLock`, `mapLock` etc.
+- Error handling
+  - Wrap errors with meaningful context before returning or logging them.
+- When logging, follow the [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+- When patching OpenShift-maintained forks of "upstream" repositories, patches should be as small as reasonably possible and should minimize touch points with code that is likely to change and impact the rebasing process.
+- Dependencies must be vendored. When making changes to dependencies, ensure you've run `go mod tidy` and `go mod vendor`.
+
+### General
+
+Regardless of the programming language, make sure to take the following into consideration:
+- Keep readability / maintainability in mind when writing code.
+  - Clever code and abstractions are often harder to reason about after the fact. Keep clever code and abstractions to the minimum necessary to accomplish the end-goal.
+- Do not reinvent the wheel. Where possible, use existing standard library or vendored library functionality. If you are adding a net-new dependency, stop and think if you _really_ need to add the new dependency to achieve your goals.
+- When writing tests, focus on testing the functional behaviors your code exercises. Avoid writing tests that are testing that the standard library works as expected or is trivial. Do not write tests just for line coverage.
+
+### Directory and File Conventions
+
+- Avoid package sprawl. Find an appropriate subdirectory for new packages.
+  - Libraries with no appropriate home belong in new package subdirectories of `pkg/util`.
+- Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the `wait` package and include functionality like `Poll`. The full name is `wait.Poll`.
+- All filenames should be lowercase.
+- Go source files and directories use underscores, not dashes.
+  - Package directories should generally avoid using separators as much as possible. When package names are multiple words, they usually should be in nested subdirectories.
+
+## Testing Guidelines
+
+These are high-level testing guidelines. Where individual component repositories may have
+additional testing guidelines to follow when making contributions.
+
+- All changes must include unit test additions/changes.
+  - Exceptions are at reviewer/approver discretion.
+- Table-driven unit tests are preferred for testing multiple scenarios/inputs. For an example, see https://github.com/openshift/cluster-authentication-operator/blob/a493799952e9b6838021ccc7d15d3d37d7ad3508/pkg/controllers/externaloidc/externaloidc_controller_test.go#L108 .
+- Unit tests must pass on all platforms (at the very least, Linux + macOS).
+- Significant features should come with integration and/or end-to-end (e2e) tests where appropriate.
+  - End-to-end tests _may_ be scoped as a separate work item when the end-to-end tests for the component must be added to the openshift/origin repository instead of the component repository. Adding e2e tests to the component repository is preferred where possible. It is up to reviewer/approver discretion whether a contribution can be merged without end-to-end tests being implemented.
+- Do not expect an asynchronous thing to happen immediately. Do not wait for one second and expect a pod to be running. Wait and retry instead.
+
+
+If necessary, manual integration testing can be done by creating a cluster using the [`Cluster Bot` Slack App](https://redhat.enterprise.slack.com/archives/D03KX7M1CRJ).
+Once you have a cluster created, you can follow some of the instructions in https://github.com/openshift/enhancements/blob/master/dev-guide/operators.md for guidance on how to
+build component images and modify cluster-operators to deploy those images.
+
+### Running checks
+
+```bash
+make verify         # Formatting, vetting, golang version checks
+make test-unit      # Unit tests
+make test-e2e       # E2E operator tests (requires cluster)
+```
+
+## Pull Request Process and Guidelines
+
+This section assumes that you have a functional understanding of `git` and how to create a pull request on GitHub.
+
+If you do not, start with [GitHub's "Getting Started" guide](https://docs.github.com/en/get-started/start-your-journey).
+
+### Prerequisites
+
+Before you commit any changes or create any pull requests, you must adhere to OpenShift contribution policies.
+Currently, that means enabling commit signature verification.
+
+See https://docs.google.com/document/d/1184EPSGunUkcSQYUK8T4a6iyawwi6f2zxdbB2jtG9nQ/edit?usp=sharing for more details on
+how to adhere to the commit signature verification policy of OpenShift.
+
+### Creating a Pull Request
+
+When creating a pull request, include the following:
+
+- A brief, but descriptive, title.
+  - All pull requests _should_ link to a Jira ticket associated with the work. There is automation that performs this linking when prefixing the title with the Jira ticket identifier like: `CNTRLPLANE-XXXX: my pull request title`. For pull requests that have no Jira ticket associated with it, you can prefix it with `NO-JIRA:` to signal that there is not a Jira ticket associated with it.
+- A useful description of the changes being made and why they are important. Include links to supporting documents and any additional context that reviewers may need.
+
+### CI / CD
+
+For CI/CD, OpenShift uses Prow to run various checks. This can include unit tests, e2e tests, linters, etc.
+
+The jobs configured for each repository are in https://github.com/openshift/release/tree/main/ci-operator/config/openshift . If you find yourself needing to add additional jobs, review the documentation at https://docs.ci.openshift.org/how-tos/contributing-openshift-release/ .
+
+There are often a mixture of required and optional checks as well as merge criteria that must be met before a pull request can merge.
+When any of these checks fail, the GitHub Prow bot will leave a comment on the PR with links to the run of that check that failed.
+
+As the PR author, it is your responsibility to evaluate the failed checks and determine if there are any changes necessary to pass the checks.
+If you suspect that the check failure was a flake, you can trigger retests by commenting `/retest` (or `/retest-required` for retesting only the required checks) on the PR.
+
+### Verifying your changes / Creating an OpenShift cluster from a PR
+
+As part of merging a PR, there is a requirement to verify that the changes you've made are working as expected using the `/verified` comment command.
+
+While there are a lot of scenarios where the existing CI/CD checks may be sufficient to verify your changes are working (and can be denoted by commenting `/verified by ci`),
+there may be scenarios where manual verification is required.
+
+You can use the `Cluster Bot` Slack App to create a cluster from a PR by sending it a message in the format of `launch ${OCP_VERSION},${PR_LINK} ${PLATFORM},${VARIANT}`.
+As an example, `launch 4.23,https://github.com/openshift/cluster-authentication-operator/pull/928 aws,techpreview` would launch an OpenShift 4.23 cluster with the changes made in openshift/cluster-authentication-operator#928 running on AWS with the TechPreviewNoUpgrade feature-set enabled.
+For more information on what `Cluster Bot` can do, you can send it a message saying `help` and it will respond with additional documentation on how it can be used.
+
+Once you've verified your changes work as expected, you can mark the PR as verified by commenting `/verified by @{your_github_handle}` on the PR.
+
+### Additional Resources
+
+For more information regarding more general OpenShift pull request processes, the following resources are helpful:
+
+- https://docs.ci.openshift.org/architecture/jira
+- https://docs.ci.openshift.org/
+- https://steps.ci.openshift.org/
+
+## Review Expectations
+
+### Requesting a review
+
+If you are not a member of the OpenShift control plane team and you need a review on a PR, post it in the [#forum-ocp-apiserver](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel or
+reach out to folks outlined in the OWNERS file directly.
+
+If you are a member of the OpenShift control plane team, reviews should come from your feature team. In the event your feature team does not have someone that can approve
+a PR, post it in the [#control-plane](https://redhat.enterprise.slack.com/archives/CC3CZCQHM) Slack channel.
+
+OpenShift uses AI code review tools as part of the code review process.
+Before requesting a review, address all feedback from the code review agent(s).
+It is up to your discretion as the contributor how you would like to address that feedback.
+Responding with an explanation as to why you are not going to take action on a comment made
+by the agent is an acceptable way to "address" its feedback.
+
+### Interacting with reviewers
+
+When interacting with reviewers/approvers:
+
+- Be professional.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Gracefully give and receive constructive feedback.
+- Focus on what is best for the product/organization, not just us as individuals.
+
+A special note on the usage of AI - to respect the time of those that are reviewing your contribution, please do not use AI to respond to review comments.
+
+## OpenShift Tests Extension (OTE)
+
+This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+
+### Building the test binary
+
+```bash
+make build
+```
+
+### Running test suites and tests
+
+```bash
+# Run a suite
+./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial
+
+# Run a specific test
+./cli-manager-operator-tests-ext run-test "test-name"
+
+# Run a suite with concurrency limited to 1 (serial execution)
+./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial -c 1
+
+# Run with JUnit output
+./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial --junit-path=/tmp/junit.xml
+```
+
+### Listing available tests and suites
+
+```bash
+# List all test suites
+./cli-manager-operator-tests-ext list suites
+
+# List tests in a suite
+./cli-manager-operator-tests-ext list tests --suite=openshift/cli-manager-operator/operator/serial
+```
+
+For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).

--- a/README.md
+++ b/README.md
@@ -74,37 +74,4 @@ This process refers to building the operator in a way that it can be installed l
 
 ## Tests
 
-This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
-
-### Building the test binary
-
-```bash
-make build
-```
-
-### Running test suites and tests
-
-```bash
-# Run a specific test suite or test
-./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial
-./cli-manager-operator-tests-ext run-test "test-name"
-
-# To run serial suites cases serially, use the following command:
-./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial -c 1
-
-# Run with JUnit output
-./cli-manager-operator-tests-ext run-suite openshift/cli-manager-operator/operator/serial --junit-path=/tmp/junit.xml
-./cli-manager-operator-tests-ext run-test "test-name" --junit-path=/tmp/junit.xml
-```
-
-### Listing available tests and suites
-
-```bash
-# List all test suites
-./cli-manager-operator-tests-ext list suites
-
-# List tests in a suite
-./cli-manager-operator-tests-ext list tests --suite=openshift/cli-manager-operator/operator/serial
-```
-
-For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for testing guidelines ([unit/e2e](CONTRIBUTING.md#testing-guidelines), [OTE](CONTRIBUTING.md#openshift-tests-extension-ote)).


### PR DESCRIPTION
Add project documentation for AI agents, architecture overview, and contribution guidelines. Deduplicate testing instructions from README into CONTRIBUTING.md.

Marking this as a draft to prevent CI until this is accepted.