### PR TITLE
CNTRLPLANE-3867: Add RBAC network policies for the operator

### DIFF
--- a/manifests/cli-manager-operator.clusterserviceversion.yaml
+++ b/manifests/cli-manager-operator.clusterserviceversion.yaml
@@ -230,6 +230,17 @@ spec:
             - update
             - patch
             - delete
+        - apiGroups:
+            - networking.k8s.io
+          resources:
+            - networkpolicies
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
         serviceAccountName: openshift-cli-manager-operator
       deployments:
         - name: openshift-cli-manager-operator

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -125,3 +125,14 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update


### PR DESCRIPTION
Adds RBAC network policy for the operator 

Issue: 

```
yshanmug@yshanmug-thinkpadp1gen7:~/Documents/dev/forks/networkpolicies/cli-manager-operator$ ec validate image     --image registry.redhat.io/cli-manager/cli-manager-operator-bundle@sha256:f84f5609ed0c329c810bb85d66f24e2be6b0ae421c9870048d6af6079f01abed     --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}'     --ignore-rekor     --skip-image-sig-check     --skip-att-sig-check     --certificate-identity-regexp '.*'     --certificate-oidc-issuer-regexp '.*'     --output text     --strict false     --info | grep -i network -A 10
WARN[0014] Image signature check skipped                
WARN[0014] Attestation signature check skipped, fetching attestations without verification 
WARN[0014] Both --skip-image-sig-check and --skip-att-sig-check are active, all cryptographic verification is disabled 
ERRO[0063] failed to fetch image                         action="fetch image" error="GET https://registry.redhat.io/v2/cli-manager/cli-manager-operator-bundle/manifests/sha256:6f2425dbf8943dc304afd7b68ad01ee792837b6997ac308bf825ac76fe4b4c5e: MANIFEST_UNKNOWN: manifest unknown; map[]" function=ec.oci.image_manifest input_ref="registry.redhat.io/cli-manager/cli-manager-operator-bundle@sha256:6f2425dbf8943dc304afd7b68ad01ee792837b6997ac308bf825ac76fe4b4c5e"
ERRO[0069] failed to fetch image                         action="fetch image" error="GET https://registry.redhat.io/v2/cli-manager/cli-manager-operator-bundle/manifests/sha256:6f2425dbf8943dc304afd7b68ad01ee792837b6997ac308bf825ac76fe4b4c5e: MANIFEST_UNKNOWN: manifest unknown; map[]" function=ec.oci.image_manifest input_ref="registry.redhat.io/cli-manager/cli-manager-operator-bundle@sha256:6f2425dbf8943dc304afd7b68ad01ee792837b6997ac308bf825ac76fe4b4c5e"
› [Warning] olm.required_network_policy_rbac_for_operands
  ImageRef: registry.redhat.io/cli-manager/cli-manager-operator-bundle@sha256:f84f5609ed0c329c810bb85d66f24e2be6b0ae421c9870048d6af6079f01abed
  Reason: Operator "cli-manager" version "0.2.0" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with
  create, delete, and update/patch)
  Title: NetworkPolicy RBAC present in OLM bundle
  Description: Operators are required to manage the network policies of their operands. This rule verifies that operator bundles
  request sufficient RBAC permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch) for
  networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles whose operator name and major.minor version are listed
  in the `operator_network_policy_rbac_exceptions` rule data key are exempt from this requirement.
  Solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies to the ClusterServiceVersion
  clusterPermissions or permissions, or add the operator name and its major.minor version to the
  operator_network_policy_rbac_exceptions rule data key.

› [Warning] tasks.pipeline_required_tasks_list_provided
  ImageRef: registry.redhat.io/cli-manager/cli-manager-operator-bundle@sha256:f84f5609ed0c329c810bb85d66f24e2be6b0ae421c9870048d6af6079f01abed
  Reason: Required tasks do not exist for pipeline
  Title: Required tasks list for pipeline was provided
  Description: Produce a warning if the required tasks list rule data was not provided.
  Solution: The required task list is contained as https://conforma.dev/docs/cli/configuration.html#_data_sources under the key
  'required-tasks'. Make sure this list exists.

› [Warning] test.no_test_warnings
Error: success criteria not met
```

**Fix-verification**
```
yshanmug@yshanmug-thinkpadp1gen7:~/Documents/dev/forks/networkpolicies/cli-manager-operator$ ec validate image --image quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-main/cli-manager-operator-bundle-main:on-pr-9d5a8e925c5404c42d277f5ae30c6feae07da7d3  --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}'     --ignore-rekor     --skip-image-sig-check     --skip-att-sig-check     --certificate-identity-regexp '.*'     --certificate-oidc-issuer-regexp '.*'     --output text     --strict false     --info | grep -i network -A 10
WARN[0017] Image signature check skipped                
WARN[0017] Attestation signature check skipped, fetching attestations without verification 
WARN[0017] Both --skip-image-sig-check and --skip-att-sig-check are active, all cryptographic verification is disabled 
Error: success criteria not met
```