### PR TITLE
NO-JIRA: Fixing the e2e tests for cli-manager operator 

### DIFF
--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -88,18 +88,19 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 
 	eventRecorder := events.NewKubeRecorder(kubeClient.CoreV1().Events("default"), "test-e2e", &corev1.ObjectReference{}, clock.RealClock{})
 
-	// Get cluster version
-	cmd := exec.Command("oc", "get", "clusterversion", "-o", "jsonpath={.items[0].status.desired.version}")
-	versionOutput, err := cmd.Output()
-	if err != nil {
-		return ctx, cancelFnc, nil, fmt.Errorf("unable to get cluster version: %w", err)
+	// Get operator image from environment variable
+	operatorImage := os.Getenv("OPERATOR_IMAGE")
+	if operatorImage == "" {
+		return ctx, cancelFnc, nil, fmt.Errorf("OPERATOR_IMAGE environment variable must be set")
 	}
-	versionParts := strings.Split(string(versionOutput), ".")
-	if len(versionParts) < 2 {
-		return ctx, cancelFnc, nil, fmt.Errorf("unable to parse cluster version: %s", string(versionOutput))
+	klog.Infof("Using operator image: %s", operatorImage)
+
+	// Get operand image from environment variable
+	operandImage := os.Getenv("OPERAND_IMAGE")
+	if operandImage == "" {
+		return ctx, cancelFnc, nil, fmt.Errorf("OPERAND_IMAGE environment variable must be set")
 	}
-	ocpVersion := fmt.Sprintf("%s.%s", versionParts[0], versionParts[1])
-	klog.Infof("Detected OCP version: %s", ocpVersion)
+	klog.Infof("Using operand image: %s", operandImage)
 
 	assets := []struct {
 		path           string
@@ -151,14 +152,11 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 			path: "assets/06_deployment.yaml",
 			readerAndApply: func(objBytes []byte) error {
 				required := resourceread.ReadDeploymentV1OrDie(objBytes)
-				// override the operator image with the one built in the CI
 
-				operatorImage := fmt.Sprintf("registry.ci.openshift.org/ocp/%s:cli-manager-operator", ocpVersion)
 				required.Spec.Template.Spec.Containers[0].Image = operatorImage
 				klog.Infof("Using operator image: %s", operatorImage)
 
 				// RELATED_IMAGE_OPERAND_IMAGE env
-				operandImage := fmt.Sprintf("registry.ci.openshift.org/ocp/%s:cli-manager", ocpVersion)
 				for i, env := range required.Spec.Template.Spec.Containers[0].Env {
 					if env.Name == "RELATED_IMAGE_OPERAND_IMAGE" {
 						required.Spec.Template.Spec.Containers[0].Env[i].Value = operandImage
@@ -194,7 +192,7 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 	}
 
 	// create required resources, e.g. namespace, crd, roles
-	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		for _, asset := range assets {
 			klog.Infof("Creating %v", asset.path)
 			if err := asset.readerAndApply(bindata.MustAsset(asset.path)); err != nil {
@@ -210,7 +208,7 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 
 	var cliManagerOperatorPod *corev1.Pod
 	// Wait until the CLI Manager Operator pod is running
-	if err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		klog.Infof("Listing pods...")
 		podItems, err := kubeClient.CoreV1().Pods(operatorclient.OperatorNamespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -236,7 +234,7 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 
 	var cliManagerPod *corev1.Pod
 	// Wait until the CLI Manager pod is running
-	if err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		klog.Infof("Listing pods...")
 		podItems, err := kubeClient.CoreV1().Pods(operatorclient.OperatorNamespace).List(ctx, metav1.ListOptions{})
 		if err != nil {


### PR DESCRIPTION
Currently the e2e tests are using the nightly image to run e2e tests, modified it to use the CI image 